### PR TITLE
Better strong name key storage

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/BasicAnalyzerHostTests.cs
@@ -1,6 +1,7 @@
 ﻿using Basic.CompilerLog.Util;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -55,9 +55,9 @@ public abstract class TestBase : IDisposable
     protected string GetBinaryLogFullPath(string? workingDirectory = null) =>
         Path.Combine(workingDirectory ?? RootDirectory, "msbuild.binlog");
 
-    protected CompilerLogReader GetReader(bool emptyDirectory = true, string? cryptoKeyFileDirectory = null)
+    protected CompilerLogReader GetReader(bool emptyDirectory = true )
     {
-        var reader = CompilerLogReader.Create(GetBinaryLogFullPath(), cryptoKeyFileDirectory);
+        var reader = CompilerLogReader.Create(GetBinaryLogFullPath());
         if (emptyDirectory)
         {
             Root.EmptyDirectory();

--- a/src/Basic.CompilerLog.Util/CompilationData.cs
+++ b/src/Basic.CompilerLog.Util/CompilationData.cs
@@ -20,7 +20,17 @@ public abstract class CompilationData
 
     public CompilerCall CompilerCall { get; } 
     public Compilation Compilation { get; }
+
+    /// <summary>
+    /// The <see cref="BasicAnalyzerHost"/> for the analyzers and generators.
+    /// </summary>
+    /// <remarks>
+    /// This is *not* owned by this instance and should not be disposed from here. The creator
+    /// of this <see cref="CompilationData"/> is responsible for managing the lifetime of this
+    /// instance.
+    /// </remarks>
     public BasicAnalyzerHost BasicAnalyzerHost { get; }
+
     public ImmutableArray<AdditionalText> AdditionalTexts { get; }
     public ImmutableArray<AnalyzerReference> AnalyzerReferences { get; }
     public AnalyzerConfigOptionsProvider AnalyzerConfigOptionsProvider { get; }

--- a/src/Basic.CompilerLog.Util/CompilerLogState.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogState.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Basic.CompilerLog.Util;
+
+/// <summary>
+/// The <see cref="CompilationData"/> have underlying state associated with them: 
+///     - File system entries to hold crypto key files
+///     - <see cref="BasicAnalyzerHost"/> which control loaded analyzers
+///
+/// Rather than have each <see cref="CompilationData"/> maintain it's own and state
+/// and be disposable, all of it is stored here. Generally this is implicitly tied
+/// to the lifetime of a <see cref="CompilerLogReader"/> but this can be explicitly
+/// managed in cases where <see cref="CompilationData"/> live longer than the 
+/// underlying reader.
+/// </summary>
+public sealed class CompilerLogState : IDisposable
+{
+    /// <summary>
+    /// The compiler supports strong named keys that exist on disk. In order for compilation to succeed at the 
+    /// Emit section, even for some binding purposes, that file must continue to exist on disk when the project
+    /// is re-hydrated.
+    /// </summary>
+    public string CryptoKeyFileDirectory { get; }
+
+    internal List<BasicAnalyzerHost> BasicAnalyzerHosts { get; } = new();
+
+    public CompilerLogState(string? cryptoKeyFileDirectoryBase = null)
+    {
+        cryptoKeyFileDirectoryBase ??= Path.GetTempPath();
+        CryptoKeyFileDirectory = Path.Combine(cryptoKeyFileDirectoryBase, "Basic.CompilerLog", Guid.NewGuid().ToString());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(CryptoKeyFileDirectory))
+        {
+            Directory.Delete(CryptoKeyFileDirectory, recursive: true);
+        }
+
+        foreach (var host in BasicAnalyzerHosts)
+        {
+            host.Dispose();
+        }
+    }
+}

--- a/src/Basic.CompilerLog.Util/CompilerLogUtil.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogUtil.cs
@@ -77,18 +77,6 @@ public static class CompilerLogUtil
         return reader.ReadAllCompilerCalls(predicate);
     }
 
-    public static List<CompilationData> ReadAllCompilationData(string compilerLogFilePath, Func<CompilerCall, bool>? predicate = null)
-    {
-        using var compilerLogStream = new FileStream(compilerLogFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        return ReadAllCompilationData(compilerLogStream, predicate);
-    }
-
-    public static List<CompilationData> ReadAllCompilationData(Stream compilerLogStream, Func<CompilerCall, bool>? predicate = null)
-    {
-        using var reader = CompilerLogReader.Create(compilerLogStream);
-        return reader.ReadAllCompilationData(predicate);
-    }
-
     private static Exception CreateException(string message, IEnumerable<string> diagnostics)
     {
         var builder = new StringBuilder();

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -404,9 +404,8 @@ int RunDiagnostics(IEnumerable<string> args)
         }
 
         using var compilerLogStream = GetOrCreateCompilerLogStream(extra);
-        var compilationDatas = CompilerLogUtil.ReadAllCompilationData(
-            compilerLogStream,
-            options.FilterCompilerCalls);
+        using var reader = CompilerLogReader.Create(compilerLogStream, leaveOpen: true);
+        var compilationDatas = reader.ReadAllCompilationData(options.FilterCompilerCalls);
 
         foreach (var compilationData in compilationDatas)
         {


### PR DESCRIPTION
Two fixes here:
1. Make strong name key storage just work when reading info. No need to explicitly pass around storage dirs
2. Clarifies the ownership model for analyzer hosts, disk artifacts, etc ... for CompilerLogReader instances

closes #31