### PR TITLE
Emit helpers

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -35,6 +35,7 @@ public sealed class CompilerLogFixture : IDisposable
         ConsoleComplogPath,
         ClassLibComplogPath,
         ClassLibMultiComplogPath,
+        ClassLibSignedComplogPath,
     };
 
     public CompilerLogFixture()
@@ -70,7 +71,7 @@ public sealed class CompilerLogFixture : IDisposable
                 }
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Program.cs"), program, TestBase.DefaultEncoding);
-            DotnetUtil.Command("build -bl", scratchPath);
+            Assert.True(DotnetUtil.Command("build -bl", scratchPath).Succeeded);
             return Path.Combine(scratchPath, "msbuild.binlog");
         });
         
@@ -97,7 +98,7 @@ public sealed class CompilerLogFixture : IDisposable
                 }
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Class1.cs"), program, TestBase.DefaultEncoding);
-            DotnetUtil.Command("build -bl", scratchPath);
+            Assert.True(DotnetUtil.Command("build -bl", scratchPath).Succeeded);
             return Path.Combine(scratchPath, "msbuild.binlog");
         });
 
@@ -127,7 +128,7 @@ public sealed class CompilerLogFixture : IDisposable
                 }
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Class1.cs"), program, TestBase.DefaultEncoding);
-            DotnetUtil.Command("build -bl", scratchPath);
+            Assert.True(DotnetUtil.Command("build -bl", scratchPath).Succeeded);
             return Path.Combine(scratchPath, "msbuild.binlog");
         });
 
@@ -149,12 +150,11 @@ public sealed class CompilerLogFixture : IDisposable
                 using System.Text.RegularExpressions;
 
                 partial class Util {
-                    [GeneratedRegex("abc|def", RegexOptions.IgnoreCase, "en-US")]
-                    internal static partial Regex GetRegex();
+                    internal static Regex GetRegex() => null!;
                 }
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Class1.cs"), program, TestBase.DefaultEncoding);
-            DotnetUtil.Command("build -bl", scratchPath);
+            Assert.True(DotnetUtil.Command("build -bl", scratchPath).Succeeded);
             return Path.Combine(scratchPath, "msbuild.binlog");
         });
 

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -225,4 +225,21 @@ public sealed class CompilerLogReaderTests : TestBase
         Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net6.0"));
         Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net7.0"));
     }
+
+    [Fact]
+    public void EmitToDisk()
+    {
+        foreach (var complogPath in Fixture.AllComplogs)
+        {
+            TestOutputHelper.WriteLine(complogPath);
+            using var reader = CompilerLogReader.Create(complogPath);
+            foreach (var data in reader.ReadAllCompilationData())
+            {
+                using var testDir = new TempDir();
+                TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
+                var emitResult = data.Emit(testDir.DirectoryPath);
+                Assert.True(emitResult.Success);
+            }
+        }
+    }
 }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -237,7 +237,23 @@ public sealed class CompilerLogReaderTests : TestBase
             {
                 using var testDir = new TempDir();
                 TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
-                var emitResult = data.Emit(testDir.DirectoryPath);
+                var emitResult = data.EmitToDisk(testDir.DirectoryPath);
+                Assert.True(emitResult.Success);
+            }
+        }
+    }
+
+    [Fact]
+    public void EmitToMemory()
+    {
+        foreach (var complogPath in Fixture.AllComplogs)
+        {
+            TestOutputHelper.WriteLine(complogPath);
+            using var reader = CompilerLogReader.Create(complogPath);
+            foreach (var data in reader.ReadAllCompilationData())
+            {
+                TestOutputHelper.WriteLine($"\t{data.CompilerCall.ProjectFileName} ({data.CompilerCall.TargetFramework})");
+                var emitResult = data.EmitToMemory();
                 Assert.True(emitResult.Success);
             }
         }

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -82,5 +82,22 @@ public sealed class ProgramTests : TestBase
         var buildResult = RunBuildCmd(exportPath);
         Assert.True(buildResult.Succeeded);
     }
+
+    [Fact]
+    public void EmitConsole()
+    {
+        using var emitDir = new TempDir();
+        RunCompLog($"emit -o {emitDir.DirectoryPath} {Fixture.ConsoleComplogPath}");
+
+        AssertOutput(@"example\emit\example.dll");
+        AssertOutput(@"example\emit\example.pdb");
+        AssertOutput(@"example\emit\ref\example.dll");
+
+        void AssertOutput(string relativePath)
+        {
+            var filePath = Path.Combine(emitDir.DirectoryPath, relativePath);
+            Assert.True(File.Exists(filePath));
+        }
+    }
 }
 #endif

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -95,6 +96,11 @@ public sealed class ProgramTests : TestBase
 
         void AssertOutput(string relativePath)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                relativePath = relativePath.Replace('\\', '/');
+            }
+
             var filePath = Path.Combine(emitDir.DirectoryPath, relativePath);
             Assert.True(File.Exists(filePath));
         }

--- a/src/Basic.CompilerLog.Util/CompilationData.cs
+++ b/src/Basic.CompilerLog.Util/CompilationData.cs
@@ -118,7 +118,11 @@ public abstract class CompilationData
     public EmitResult Emit(string directory)
     {
         var compilation = GetCompilationAfterGenerators();
-        compilation.Emit()
+        compilation.Emit();
+        _commandLineArguments.get   
+
+
+        ResourceDescription d;
 
 
         // pdbStream allowed except embedded PDB or EmitMetadataOnly

--- a/src/Basic.CompilerLog.Util/CompilationData.cs
+++ b/src/Basic.CompilerLog.Util/CompilationData.cs
@@ -31,6 +31,8 @@ public abstract class CompilationData
     /// </remarks>
     public BasicAnalyzerHost BasicAnalyzerHost { get; }
 
+    public EmitData EmitData { get; }
+
     public ImmutableArray<AdditionalText> AdditionalTexts { get; }
     public ImmutableArray<AnalyzerReference> AnalyzerReferences { get; }
     public AnalyzerConfigOptionsProvider AnalyzerConfigOptionsProvider { get; }
@@ -44,6 +46,7 @@ public abstract class CompilationData
     private protected CompilationData(
         CompilerCall compilerCall,
         Compilation compilation,
+        EmitData emitData,
         CommandLineArguments commandLineArguments,
         ImmutableArray<AdditionalText> additionalTexts,
         BasicAnalyzerHost basicAnalyzerHost,
@@ -51,6 +54,7 @@ public abstract class CompilationData
     {
         CompilerCall = compilerCall;
         Compilation = compilation;
+        EmitData = emitData;
         _commandLineArguments = commandLineArguments;
         AdditionalTexts = additionalTexts;
         BasicAnalyzerHost = basicAnalyzerHost;
@@ -110,6 +114,27 @@ public abstract class CompilationData
     }
 
     protected abstract GeneratorDriver CreateGeneratorDriver();
+
+    public EmitResult Emit(string directory)
+    {
+        var compilation = GetCompilationAfterGenerators();
+        compilation.Emit()
+
+
+        // pdbStream allowed except embedded PDB or EmitMetadataOnly
+        // metadataPEStream allowed except emit metadata only (then it's pestream) or includePrivatemembers ro netmeodule
+        // xmldoc path if it was specified in the arguments
+
+    }
+
+    private bool IncludePdbStream() =>
+        EmitOptions.DebugInformationFormat != DebugInformationFormat.Embedded &&
+        !EmitOptions.EmitMetadataOnly;
+
+    private bool IncludeMetadataStream() =>
+        !EmitOptions.EmitMetadataOnly &&
+        !EmitOptions.IncludePrivateMembers &&
+        CompilationOptions.OutputKind != OutputKind.NetModule;
 }
 
 public abstract class CompilationData<TCompilation, TParseOptions> : CompilationData
@@ -122,11 +147,12 @@ public abstract class CompilationData<TCompilation, TParseOptions> : Compilation
     private protected CompilationData(
         CompilerCall compilerCall,
         TCompilation compilation,
+        EmitData emitData,
         CommandLineArguments commandLineArguments,
         ImmutableArray<AdditionalText> additionalTexts,
         BasicAnalyzerHost basicAnalyzerHost,
         AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
-        :base(compilerCall, compilation, commandLineArguments, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider)
+        :base(compilerCall, compilation, emitData, commandLineArguments, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider)
     {
         
     }
@@ -137,11 +163,12 @@ public sealed class CSharpCompilationData : CompilationData<CSharpCompilation, C
     internal CSharpCompilationData(
         CompilerCall compilerCall,
         CSharpCompilation compilation,
+        EmitData emitData,
         CSharpCommandLineArguments commandLineArguments,
         ImmutableArray<AdditionalText> additionalTexts,
         BasicAnalyzerHost basicAnalyzerHost,
         AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
-        :base(compilerCall, compilation, commandLineArguments, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider)
+        :base(compilerCall, compilation, emitData, commandLineArguments, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider)
     {
 
     }
@@ -155,11 +182,12 @@ public sealed class VisualBasicCompilationData : CompilationData<VisualBasicComp
     internal VisualBasicCompilationData(
         CompilerCall compilerCall,
         VisualBasicCompilation compilation,
+        EmitData emitData,
         VisualBasicCommandLineArguments commandLineArguments,
         ImmutableArray<AdditionalText> additionalTexts,
         BasicAnalyzerHost basicAnalyzerHost,
         AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
-        : base(compilerCall, compilation, commandLineArguments, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider)
+        : base(compilerCall, compilation, emitData, commandLineArguments, additionalTexts, basicAnalyzerHost, analyzerConfigOptionsProvider)
     {
     }
 

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -174,6 +174,7 @@ public sealed class CompilerLogReader : IDisposable
                 case RawContentKind.AppConfig:
                 case RawContentKind.Win32Manifest:
                 case RawContentKind.Win32Icon:
+                    break;
                 default:
                     throw new InvalidOperationException();
             }

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -254,11 +254,16 @@ public sealed class CompilerLogReader : IDisposable
                 });
 
             var (syntaxProvider, analyzerProvider) = CreateOptionsProviders(syntaxTrees, additionalTextList);
+
+            csharpOptions = csharpOptions
+                .WithSyntaxTreeOptionsProvider(syntaxProvider)
+                .WithStrongNameProvider(new DesktopStrongNameProvider());
+
             var compilation = CSharpCompilation.Create(
                 rawCompilationData.Arguments.CompilationName,
                 syntaxTrees,
                 referenceList,
-                csharpOptions.WithSyntaxTreeOptionsProvider(syntaxProvider));
+                csharpOptions);
 
             return new CSharpCompilationData(
                 compilerCall,
@@ -287,11 +292,15 @@ public sealed class CompilerLogReader : IDisposable
 
             var (syntaxProvider, analyzerProvider) = CreateOptionsProviders(syntaxTrees, additionalTextList);
 
+            basicOptions = basicOptions
+                .WithSyntaxTreeOptionsProvider(syntaxProvider)
+                .WithStrongNameProvider(new DesktopStrongNameProvider());
+
             var compilation = VisualBasicCompilation.Create(
                 rawCompilationData.Arguments.CompilationName,
                 syntaxTrees,
                 referenceList,
-                basicOptions.WithSyntaxTreeOptionsProvider(syntaxProvider));
+                basicOptions);
 
             return new VisualBasicCompilationData(
                 compilerCall,

--- a/src/Basic.CompilerLog.Util/EmitData.cs
+++ b/src/Basic.CompilerLog.Util/EmitData.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -27,5 +28,37 @@ public sealed class EmitData
         SourceLinkStream = sourceLinkStream;
         Resources = resources;
         EmbeddedTexts = embeddedTexts;
+    }
+}
+
+public readonly struct EmitDiskResult
+{
+    public bool Success { get; }
+    public string Directory { get; }
+    public string AssemblyFileName { get; }
+    public string AssemblyFilePath { get; }
+    public string? PdbFilePath { get; }
+    public string? XmlFilePath { get; }
+    public string? MetadataFilePath { get; }
+    public ImmutableArray<Diagnostic> Diagnostics { get; }
+
+    public EmitDiskResult(
+        bool success,
+        string directory,
+        string assemblyFileName,
+        string assemblyFilePath,
+        string? pdbFilePath,
+        string? xmlFilePath,
+        string? metadataFilePath,
+        ImmutableArray<Diagnostic> diagnostics)
+    {
+        Success = success;
+        Directory = directory;
+        AssemblyFileName = assemblyFileName;
+        AssemblyFilePath = assemblyFilePath;
+        PdbFilePath = pdbFilePath;
+        XmlFilePath = xmlFilePath;
+        MetadataFilePath  = metadataFilePath;
+        Diagnostics = diagnostics;
     }
 }

--- a/src/Basic.CompilerLog.Util/EmitData.cs
+++ b/src/Basic.CompilerLog.Util/EmitData.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Basic.CompilerLog.Util;
+
+/// <summary>
+/// Data about a compilation that is only interesting at Emit time
+/// </summary>
+public sealed class EmitData
+{
+    public Stream? Win32ResourceStream { get; }
+    public Stream? Win32IconStream { get; }
+    public Stream? SourceLinkStream { get; }
+
+    public EmitData(
+        Stream? win32ResourceStream,
+        Stream? win32IconStream,
+        Stream? sourceLinkStream
+        )
+    {
+        Win32ResourceStream = win32ResourceStream;
+        Win32IconStream = win32IconStream;
+        SourceLinkStream = sourceLinkStream;
+    }
+}

--- a/src/Basic.CompilerLog.Util/EmitData.cs
+++ b/src/Basic.CompilerLog.Util/EmitData.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.CodeAnalysis;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,17 +13,19 @@ namespace Basic.CompilerLog.Util;
 public sealed class EmitData
 {
     public Stream? Win32ResourceStream { get; }
-    public Stream? Win32IconStream { get; }
     public Stream? SourceLinkStream { get; }
+    public IEnumerable<ResourceDescription>? Resources { get; }
+    public IEnumerable<EmbeddedText>? EmbeddedTexts { get; }
 
     public EmitData(
         Stream? win32ResourceStream,
-        Stream? win32IconStream,
-        Stream? sourceLinkStream
-        )
+        Stream? sourceLinkStream,
+        IEnumerable<ResourceDescription>? resources,
+        IEnumerable<EmbeddedText>? embeddedTexts)
     {
         Win32ResourceStream = win32ResourceStream;
-        Win32IconStream = win32IconStream;
         SourceLinkStream = sourceLinkStream;
+        Resources = resources;
+        EmbeddedTexts = embeddedTexts;
     }
 }

--- a/src/Basic.CompilerLog.Util/EmitData.cs
+++ b/src/Basic.CompilerLog.Util/EmitData.cs
@@ -62,3 +62,29 @@ public readonly struct EmitDiskResult
         Diagnostics = diagnostics;
     }
 }
+
+public readonly struct EmitMemoryResult
+{
+    public bool Success { get; }
+    public MemoryStream AssemblyStream { get; }
+    public MemoryStream? PdbStream { get; }
+    public MemoryStream? XmlStream { get; }
+    public MemoryStream? MetadataStream { get; }
+    public ImmutableArray<Diagnostic> Diagnostics { get; }
+
+    public EmitMemoryResult(
+        bool success,
+        MemoryStream assemblyStream,
+        MemoryStream? pdbStream,
+        MemoryStream? xmlStream,
+        MemoryStream? metadataStream,
+        ImmutableArray<Diagnostic> diagnostics)
+    {
+        Success = success;
+        AssemblyStream = assemblyStream;
+        PdbStream = pdbStream;
+        XmlStream = xmlStream;
+        MetadataStream = metadataStream;
+        Diagnostics = diagnostics;
+    }
+}

--- a/src/Basic.CompilerLog.Util/Extensions.cs
+++ b/src/Basic.CompilerLog.Util/Extensions.cs
@@ -58,8 +58,8 @@ internal static class Extensions
     /// is for consumers to be able to access the underlying array via <see cref="MemoryStream.TryGetBuffer(out ArraySegment{byte})"/>
     /// and similar methods.
     /// </summary>
-    internal static MemoryStream AsSimpleMemoryStream(this byte[] array) =>
-        new MemoryStream(array, 0, count: array.Length, writable: true, publiclyVisible: true);
+    internal static MemoryStream AsSimpleMemoryStream(this byte[] array, bool writable = true) =>
+        new MemoryStream(array, 0, count: array.Length, writable: writable, publiclyVisible: true);
 
     internal static string GetResourceName(this ResourceDescription d) => ReflectionUtil.ReadField<string>(d, "ResourceName");
     internal static string? GetFileName(this ResourceDescription d) => ReflectionUtil.ReadField<string?>(d, "FileName");

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -302,5 +302,7 @@ file sealed class BasicAnalyzerReference : AnalyzerReference
             .Single();
         return ctor.Invoke(null);
     }
+
+    public override string ToString() => $"In Memory {AssemblyName}";
 }
 

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostInMemory.cs
@@ -239,10 +239,24 @@ file sealed class BasicAnalyzerReference : AnalyzerReference
         return builder.ToImmutable();
     }
 
+    internal Type[] GetTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch
+        {
+            // TODO: need to handle the load errors here same way as compiler. The CodeFixProvider assemblies
+            // not loading shouldn't lead to not generating anything.
+            return Array.Empty<Type>();
+        }
+    }
+
     internal void GetAnalyzers(ImmutableArray<DiagnosticAnalyzer>.Builder builder, string? languageName)
     {
         var assembly = Loader.LoadFromAssemblyName(AssemblyName);
-        foreach (var type in assembly.GetTypes())
+        foreach (var type in GetTypes(assembly))
         {
             if (type.GetCustomAttributes(inherit: false) is { Length: > 0 } attributes)
             {
@@ -265,7 +279,7 @@ file sealed class BasicAnalyzerReference : AnalyzerReference
     internal void GetGenerators(ImmutableArray<ISourceGenerator>.Builder builder, string? languageName)
     {
         var assembly = Loader.LoadFromAssemblyName(AssemblyName);
-        foreach (var type in assembly.GetTypes())
+        foreach (var type in GetTypes(assembly))
         {
             if (type.GetCustomAttributes(inherit: false) is { Length: > 0 } attributes)
             {

--- a/src/Shared/DotnetUtil.cs
+++ b/src/Shared/DotnetUtil.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -24,7 +25,7 @@ internal static class DotnetUtil
     {
         // TODO: has to be a better way to find the runtime directory but this works for the moment
         var path = Path.GetDirectoryName(typeof(object).Assembly.Location);
-        while (path is not null && Path.GetFileName(path) != "dotnet")
+        while (path is not null && !IsDotNetDir(path))
         {
             path = Path.GetDirectoryName(path);
         }
@@ -35,6 +36,18 @@ internal static class DotnetUtil
         }
 
         return GetSdkDirectories(path);
+
+        static bool IsDotNetDir(string path)
+        {
+            var appName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? "dotnet.exe"
+                : "dotnet";
+
+            return
+                File.Exists(Path.Combine(path, appName)) &&
+                Directory.Exists(Path.Combine(path, "sdk")) &&
+                Directory.Exists(Path.Combine(path, "host"));
+        }
     }
 
     internal static List<string> GetSdkDirectories(string dotnetDirectory)


### PR DESCRIPTION
Couple changes:

- Adds simple helpers for emitting the compilation into memory or disk. 
- Adds an `emit` command that emits all binaries in the compiler log. This is helpful for testing the tool is working correctly.

closes #30