### PR TITLE
Handle more compiler calls

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -30,12 +30,15 @@ public sealed class CompilerLogFixture : IDisposable
     /// </summary>
     internal string ClassLibMultiComplogPath { get; }
 
+    internal string WpfAppComplogPath { get; }
+
     internal IEnumerable<string> AllComplogs => new[]
     {
         ConsoleComplogPath,
         ClassLibComplogPath,
         ClassLibMultiComplogPath,
         ClassLibSignedComplogPath,
+        WpfAppComplogPath
     };
 
     public CompilerLogFixture()
@@ -46,7 +49,7 @@ public sealed class CompilerLogFixture : IDisposable
 
         ConsoleComplogPath = WithBuild("console.complog", static string (string scratchPath) =>
         {
-            DotnetUtil.Command($"new console --name example --output .", scratchPath);
+            DotnetUtil.CommandOrThrow($"new console --name example --output .", scratchPath);
             var projectFileContent = """
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
@@ -77,7 +80,7 @@ public sealed class CompilerLogFixture : IDisposable
         
         ClassLibComplogPath = WithBuild("classlib.complog", static string (string scratchPath) =>
         {
-            DotnetUtil.Command($"new classlib --name example --output .", scratchPath);
+            DotnetUtil.CommandOrThrow($"new classlib --name example --output .", scratchPath);
             var projectFileContent = """
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
@@ -104,7 +107,7 @@ public sealed class CompilerLogFixture : IDisposable
 
         ClassLibSignedComplogPath = WithBuild("classlibsigned.complog", static string (string scratchPath) =>
         {
-            DotnetUtil.Command($"new classlib --name example --output .", scratchPath);
+            DotnetUtil.CommandOrThrow($"new classlib --name example --output .", scratchPath);
             var keyFilePath = Path.Combine(scratchPath, "Key.snk");
             var projectFileContent = $"""
                 <Project Sdk="Microsoft.NET.Sdk">
@@ -134,7 +137,7 @@ public sealed class CompilerLogFixture : IDisposable
 
         ClassLibMultiComplogPath = WithBuild("classlibmulti.complog", static string (string scratchPath) =>
         {
-            DotnetUtil.Command($"new classlib --name example --output .", scratchPath);
+            DotnetUtil.CommandOrThrow($"new classlib --name example --output .", scratchPath);
             var projectFileContent = """
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
@@ -158,6 +161,12 @@ public sealed class CompilerLogFixture : IDisposable
             return Path.Combine(scratchPath, "msbuild.binlog");
         });
 
+        WpfAppComplogPath = WithBuild("wpfapp.complog", static string (string scratchPath) =>
+        {
+            Assert.True(DotnetUtil.Command("new wpf --name example --output .", scratchPath).Succeeded);
+            Assert.True(DotnetUtil.Command("build -bl", scratchPath).Succeeded);
+            return Path.Combine(scratchPath, "msbuild.binlog");
+        });
 
         string WithBuild(string name, Func<string, string> action)
         {

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design.Serialization;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -229,6 +230,7 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void EmitToDisk()
     {
+        Assert.NotEmpty(Fixture.AllComplogs);
         foreach (var complogPath in Fixture.AllComplogs)
         {
             TestOutputHelper.WriteLine(complogPath);
@@ -246,6 +248,7 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void EmitToMemory()
     {
+        Assert.NotEmpty(Fixture.AllComplogs);
         foreach (var complogPath in Fixture.AllComplogs)
         {
             TestOutputHelper.WriteLine(complogPath);
@@ -293,10 +296,14 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void KindWpf()
     {
-        using var reader = CompilerLogReader.Create(Fixture.WpfAppComplogPath);
-        var list = reader.ReadAllCompilationData();
-        Assert.Equal(2, list.Count);
-        Assert.Equal(CompilerCallKind.WpfTemporaryCompile, list[0].Kind);
-        Assert.Equal(CompilerCallKind.Regular, list[1].Kind);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.NotNull(Fixture.WpfAppComplogPath);
+            using var reader = CompilerLogReader.Create(Fixture.WpfAppComplogPath);
+            var list = reader.ReadAllCompilationData();
+            Assert.Equal(2, list.Count);
+            Assert.Equal(CompilerCallKind.WpfTemporaryCompile, list[0].Kind);
+            Assert.Equal(CompilerCallKind.Regular, list[1].Kind);
+        }
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -134,7 +134,6 @@ public sealed class CompilerLogReaderTests : TestBase
         Assert.False(File.Exists(data.CompilationOptions.CryptoKeyFile));
     }
 
-
     [Fact]
     public void AnalyzerLoadOptions()
     {
@@ -289,5 +288,15 @@ public sealed class CompilerLogReaderTests : TestBase
         var compilation2 = data.GetCompilationAfterGenerators();
         Assert.Same(compilation1, compilation2);
         Assert.Empty(data.AnalyzerReferences);
+    }
+
+    [Fact]
+    public void KindWpf()
+    {
+        using var reader = CompilerLogReader.Create(Fixture.WpfAppComplogPath);
+        var list = reader.ReadAllCompilationData();
+        Assert.Equal(2, list.Count);
+        Assert.Equal(CompilerCallKind.WpfTemporaryCompile, list[0].Kind);
+        Assert.Equal(CompilerCallKind.Regular, list[1].Kind);
     }
 }

--- a/src/Basic.CompilerLog.Util/BinaryLogUtil.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogUtil.cs
@@ -91,12 +91,7 @@ public static class BinaryLogUtil
                 return null;
             }
 
-            if (Kind is not { } kind)
-            {
-                diagnosticList.Add($"Project {ProjectFile} ({TargetFramework}): cannot find CoreCompile");
-                return null;
-            }
-
+            var kind = Kind ?? CompilerCallKind.Unknown;
             var args = CommandLineParser.SplitCommandLineIntoArguments(CommandLineArguments, removeHashComments: true);
             var rawArgs = IsCSharp
                 ? SkipCompilerExecutable(args, "csc.exe", "csc.dll").ToArray()
@@ -193,16 +188,18 @@ public static class BinaryLogUtil
                 {
                     var callKind = e.TargetName switch
                     {
+                        "CoreCompile" when e.ParentTarget == "_CompileTemporaryAssembly" => CompilerCallKind.WpfTemporaryCompile,
                         "CoreCompile" => CompilerCallKind.Regular,
                         "CoreGenerateSatelliteAssemblies" => CompilerCallKind.Satellite,
                         "XamlPreCompile" => CompilerCallKind.XamlPreCompile,
-                        _ => CompilerCallKind.Unknown
+                        _ => (CompilerCallKind?)null
                     };
 
-                    if (context.TargetId != BuildEventContext.InvalidTargetId &&
+                    if (callKind is { } ck &&
+                        context.TargetId != BuildEventContext.InvalidTargetId &&
                         contextMap.TryGetValue(context.ProjectContextId, out var data))
                     {
-                        data.GetOrCreateTaskData(context.TargetId).Kind = callKind;
+                        data.GetOrCreateTaskData(context.TargetId).Kind = ck;
                     }
 
                     break;

--- a/src/Basic.CompilerLog.Util/BinaryLogUtil.cs
+++ b/src/Basic.CompilerLog.Util/BinaryLogUtil.cs
@@ -195,14 +195,14 @@ public static class BinaryLogUtil
                     {
                         "CoreCompile" => CompilerCallKind.Regular,
                         "CoreGenerateSatelliteAssemblies" => CompilerCallKind.Satellite,
-                        _ => (CompilerCallKind?)null
+                        "XamlPreCompile" => CompilerCallKind.XamlPreCompile,
+                        _ => CompilerCallKind.Unknown
                     };
 
-                    if (callKind is { } ck && 
-                        context.TargetId != BuildEventContext.InvalidTargetId &&
+                    if (context.TargetId != BuildEventContext.InvalidTargetId &&
                         contextMap.TryGetValue(context.ProjectContextId, out var data))
                     {
-                        data.GetOrCreateTaskData(context.TargetId).Kind = ck;
+                        data.GetOrCreateTaskData(context.TargetId).Kind = callKind;
                     }
 
                     break;

--- a/src/Basic.CompilerLog.Util/CompilationData.cs
+++ b/src/Basic.CompilerLog.Util/CompilationData.cs
@@ -42,6 +42,7 @@ public abstract class CompilationData
     public ParseOptions ParseOptions => _commandLineArguments.ParseOptions;
     public bool IsCSharp => Compilation is CSharpCompilation;
     public bool VisualBasic => !IsCSharp;
+    public CompilerCallKind Kind => CompilerCall.Kind;
 
     private protected CompilationData(
         CompilerCall compilerCall,

--- a/src/Basic.CompilerLog.Util/CompilerCall.cs
+++ b/src/Basic.CompilerLog.Util/CompilerCall.cs
@@ -13,6 +13,11 @@ public enum CompilerCallKind
     Satellite,
 
     /// <summary>
+    /// Temporary assembly generated for WPF projects
+    /// </summary>
+    WpfTemporaryCompile,
+
+    /// <summary>
     /// Compilation that occurs in the XAML pipeline to create a temporary assembly used 
     /// to reflect on to generate types for the real compilation
     /// </summary>

--- a/src/Basic.CompilerLog.Util/CompilerCall.cs
+++ b/src/Basic.CompilerLog.Util/CompilerCall.cs
@@ -2,8 +2,26 @@
 
 public enum CompilerCallKind
 {
+    /// <summary>
+    /// Standard compilation call that goes through the C# / VB targets
+    /// </summary>
     Regular,
-    Satellite
+
+    /// <summary>
+    /// Compilation to build a satellite assembly
+    /// </summary>
+    Satellite,
+
+    /// <summary>
+    /// Compilation that occurs in the XAML pipeline to create a temporary assembly used 
+    /// to reflect on to generate types for the real compilation
+    /// </summary>
+    XamlPreCompile,
+
+    /// <summary>
+    /// Compilation that doesn't fit existing classifications
+    /// </summary>
+    Unknown
 }
 
 public sealed class CompilerCall
@@ -29,7 +47,16 @@ public sealed class CompilerCall
         Index = index;
     }
 
-    public string GetDiagnosticName() => string.IsNullOrEmpty(TargetFramework)
-        ? ProjectFileName
-        : $"{ProjectFileName} ({TargetFramework})";
+    public string GetDiagnosticName() 
+    {
+        var baseName = string.IsNullOrEmpty(TargetFramework)
+            ? ProjectFileName
+            : $"{ProjectFileName} ({TargetFramework})";
+        if (Kind != CompilerCallKind.Regular)
+        {
+            return $"{baseName} ({Kind})";
+        }
+
+        return baseName;
+    }
 }

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -55,7 +55,6 @@ public sealed class SolutionReader : IDisposable
 
     public SolutionInfo ReadSolutionInfo()
     {
-        var guard = new object();
         var projectInfoList = new List<ProjectInfo>();
         for (var i = 0; i < ProjectCount; i++)
         {

--- a/src/Basic.CompilerLog/FilterOptionSet.cs
+++ b/src/Basic.CompilerLog/FilterOptionSet.cs
@@ -4,13 +4,13 @@ using Mono.Options;
 internal sealed class FilterOptionSet : OptionSet
 {
     internal List<string> TargetFrameworks { get; } = new();
-    internal bool IncludeSatelliteAssemblies { get; set; }
+    internal bool IncludeAllKinds { get; set; }
     internal string? ProjectName { get; set; }
     internal bool Help { get; set; }
 
     internal FilterOptionSet()
     {
-        Add("satellite", "include satellite asseblies", s => { if (s != null) IncludeSatelliteAssemblies = true; });
+        Add("include", "include all compilation kinds", i => { if (i != null) IncludeAllKinds = true; });
         Add("targetframework=", "include only compilations for the target framework (allows multiple)", TargetFrameworks.Add);
         Add("n|projectName=", "include only compilations with the project name", (string n) => ProjectName = n);
         Add("h|help", "print help", h => { if (h != null) Help = true; });
@@ -18,7 +18,7 @@ internal sealed class FilterOptionSet : OptionSet
 
     internal bool FilterCompilerCalls(CompilerCall compilerCall)
     {
-        if (!IncludeSatelliteAssemblies && compilerCall.Kind == CompilerCallKind.Satellite)
+        if (compilerCall.Kind != CompilerCallKind.Regular && !IncludeAllKinds)
         {
             return false;
         }

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -178,12 +178,7 @@ int RunPrint(IEnumerable<string> args)
 
         foreach (var compilerCall in compilerCalls)
         {
-            Write(compilerCall.GetDiagnosticName());
-            if (compilerCall.Kind == CompilerCallKind.Satellite)
-            {
-                Write(" (satellite)");
-            }
-            WriteLine();
+            WriteLine(compilerCall.GetDiagnosticName());
         }
 
         return ExitSuccess;

--- a/src/Shared/DotnetUtil.cs
+++ b/src/Shared/DotnetUtil.cs
@@ -17,6 +17,14 @@ internal static class DotnetUtil
             args,
             workingDirectory: workingDirectory);
 
+    internal static void CommandOrThrow(string args, string? workingDirectory = null)
+    {
+        if (!Command(args, workingDirectory).Succeeded)
+        {
+            throw new Exception("Command failed");
+        }
+    }
+
     internal static ProcessResult New(string args, string? workingDirectory = null) => Command($"new {args}", workingDirectory);
 
     internal static ProcessResult Build(string args, string? workingDirectory = null) => Command($"build {args}", workingDirectory);


### PR DESCRIPTION
Pull request #41 revealed that the tool isn't handling all compilations in the binary log. It was only handling the subset that was pre-recognized by the tool heuristics. This PR changes the tool to instead handle all compilations and then categorize them by the same heuristic. There is a new `Unknown` bucket for the ones unrecognized by the tool that can be used. 