### PR TITLE
Improve the None host 

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -22,6 +22,8 @@ public sealed class CompilerLogFixture : IDisposable
 
     internal string ConsoleComplogPath { get; }
 
+    internal string ConsoleNoGeneratorComplogPath { get; }
+
     internal string ClassLibComplogPath { get; }
 
     internal string ClassLibSignedComplogPath { get; }
@@ -69,6 +71,13 @@ public sealed class CompilerLogFixture : IDisposable
                 }
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Program.cs"), program, TestBase.DefaultEncoding);
+            Assert.True(DotnetUtil.Command("build -bl", scratchPath).Succeeded);
+            return Path.Combine(scratchPath, "msbuild.binlog");
+        });
+
+        ConsoleNoGeneratorComplogPath = WithBuild("console-no-generator.complog", static string (string scratchPath) =>
+        {
+            DotnetUtil.CommandOrThrow($"new console --name example --output .", scratchPath);
             Assert.True(DotnetUtil.Command("build -bl", scratchPath).Succeeded);
             return Path.Combine(scratchPath, "msbuild.binlog");
         });

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -1,9 +1,11 @@
 ﻿using Basic.CompilerLog.Util;
+using Basic.CompilerLog.Util.Impl;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design.Serialization;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -263,7 +265,7 @@ public sealed class CompilerLogReaderTests : TestBase
     }
 
     [Fact]
-    public void NoAnalyzersGeneratedFilesInRaw()
+    public void NoneHostGeneratedFilesInRaw()
     {
         using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath, BasicAnalyzerHostOptions.None);
         var (_, data) = reader.ReadRawCompilationData(0);
@@ -271,7 +273,7 @@ public sealed class CompilerLogReaderTests : TestBase
     }
 
     [Fact]
-    public void NoAnalyzerGeneratedFilesShouldBeLast()
+    public void NoneHostGeneratedFilesShouldBeLast()
     {
         using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath, BasicAnalyzerHostOptions.None);
         var data = reader.ReadCompilationData(0);
@@ -283,7 +285,7 @@ public sealed class CompilerLogReaderTests : TestBase
     }
 
     [Fact]
-    public void NoAnalyzerAddsFakeGeneratorForGeneratedSource()
+    public void NoneHostAddsFakeGeneratorForGeneratedSource()
     {
         using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath, BasicAnalyzerHostOptions.None);
         var data = reader.ReadCompilationData(0);
@@ -294,7 +296,7 @@ public sealed class CompilerLogReaderTests : TestBase
     }
 
     [Fact]
-    public void NoAnalyzerAddsNoGeneratorIfNoGeneratedSource()
+    public void NoneHostAddsNoGeneratorIfNoGeneratedSource()
     {
         using var reader = CompilerLogReader.Create(Fixture.ConsoleNoGeneratorComplogPath, BasicAnalyzerHostOptions.None);
         var data = reader.ReadCompilationData(0);
@@ -303,6 +305,34 @@ public sealed class CompilerLogReaderTests : TestBase
         Assert.Same(compilation1, compilation2);
         Assert.Empty(data.AnalyzerReferences);
     }
+
+    [Fact]
+    public void NoneHostNativePdb()
+    {
+        RunDotNet($"new console --name example --output .");
+        var projectFileContent = """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <DebugType>Full</DebugType>
+                <TargetFramework>net7.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """;
+        File.WriteAllText(Path.Combine(RootDirectory, "example.csproj"), projectFileContent, DefaultEncoding);
+        RunDotNet("build -bl");
+
+        using var reader = CompilerLogReader.Create(Path.Combine(RootDirectory, "msbuild.binlog"), BasicAnalyzerHostOptions.None);
+        var rawData = reader.ReadRawCompilationData(0).Item2;
+        Assert.False(rawData.ReadGeneratedFiles);
+        var data = reader.ReadCompilationData(0);
+        var compilation = data.GetCompilationAfterGenerators(out var diagnostics);
+        Assert.Single(diagnostics);
+        Assert.Equal(BasicAnalyzerHostNone.CannotReadGeneratedFiles.Id, diagnostics[0].Id);
+    }
+
     [Fact]
     public void KindWpf()
     {

--- a/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ProgramTests.cs
@@ -84,11 +84,13 @@ public sealed class ProgramTests : TestBase
         Assert.True(buildResult.Succeeded);
     }
 
-    [Fact]
-    public void EmitConsole()
+    [Theory]
+    [InlineData("")]
+    [InlineData("-none")]
+    public void EmitConsole(string arg)
     {
         using var emitDir = new TempDir();
-        RunCompLog($"emit -o {emitDir.DirectoryPath} {Fixture.ConsoleComplogPath}");
+        RunCompLog($"emit {arg} -o {emitDir.DirectoryPath} {Fixture.ConsoleComplogPath}");
 
         AssertOutput(@"example\emit\example.dll");
         AssertOutput(@"example\emit\example.pdb");

--- a/src/Basic.CompilerLog.UnitTests/ResilientDirectoryTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ResilientDirectoryTests.cs
@@ -1,0 +1,68 @@
+﻿using Basic.CompilerLog.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Basic.CompilerLog.UnitTests;
+
+public sealed class ResilientDirectoryTests
+{
+    public string RootPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? @"c:\"
+        : "/";
+
+    [Fact]
+    public void GetNewFilePathFlatten1()
+    {
+        using var tempDir = new TempDir();
+        var dir = new ResilientDirectory(tempDir.DirectoryPath, flatten: true);
+        var path1 = dir.GetNewFilePath(Path.Combine(RootPath, "temp1", "resource.txt"));
+        var path2 = dir.GetNewFilePath(Path.Combine(RootPath, "temp2", "resource.txt"));
+        Assert.NotEqual(path1, path2);
+        Assert.Equal(Path.Combine(tempDir.DirectoryPath, "resource.txt"), path1);
+        Assert.Equal("resource.txt", Path.GetFileName(path2));
+    }
+
+    [Fact]
+    public void GetNewFilePathFlatten2()
+    {
+        using var tempDir = new TempDir();
+        var dir = new ResilientDirectory(tempDir.DirectoryPath, flatten: true);
+        var originalPath = Path.Combine(RootPath, "temp", "resource.txt");
+        var path1 = dir.GetNewFilePath(originalPath);
+        var path2 = dir.GetNewFilePath(originalPath);
+        Assert.Equal(path1, path2);
+        Assert.Equal(Path.Combine(tempDir.DirectoryPath, "resource.txt"), path1);
+    }
+
+    [Fact]
+    public void GetNewFilePath1()
+    {
+        using var tempDir = new TempDir();
+        var dir = new ResilientDirectory(tempDir.DirectoryPath, flatten: false);
+        var path1 = dir.GetNewFilePath(Path.Combine(RootPath, "temp1", "resource.txt"));
+        var path2 = dir.GetNewFilePath(Path.Combine(RootPath, "temp2", "resource.txt"));
+        Assert.NotEqual(path1, path2);
+        Assert.NotEqual(Path.Combine(tempDir.DirectoryPath, "resource.txt"), path1);
+        Assert.NotEqual(Path.Combine(tempDir.DirectoryPath, "resource.txt"), path2);
+        Assert.Equal("resource.txt", Path.GetFileName(path1));
+        Assert.Equal("resource.txt", Path.GetFileName(path2));
+    }
+
+    [Fact]
+    public void GetNewFilePath2()
+    {
+        using var tempDir = new TempDir();
+        var dir = new ResilientDirectory(tempDir.DirectoryPath, flatten: false);
+        var originalPath = Path.Combine(RootPath, "temp", "resource.txt");
+        var path1 = dir.GetNewFilePath(originalPath);
+        var path2 = dir.GetNewFilePath(originalPath);
+        Assert.Equal(path1, path2);
+        Assert.NotEqual(Path.Combine(tempDir.DirectoryPath, "resource.txt"), path1);
+        Assert.Equal("resource.txt", Path.GetFileName(path1));
+    }
+}

--- a/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
@@ -40,28 +40,19 @@ public sealed class SolutionReaderTests : TestBase
     public void LoadAllWithoutAnalyzers() =>
         LoadAllCore(BasicAnalyzerHostOptions.None);
 
-    [Fact]
-    public async Task DocumentsHaveGeneratedTextWithAnalyzers()
+    [Theory]
+    [InlineData(BasicAnalyzerKind.Default)]
+    [InlineData(BasicAnalyzerKind.None)]
+    public async Task DocumentsHaveGeneratedTextWithAnalyzers(BasicAnalyzerKind kind)
     {
-        using var reader = SolutionReader.Create(Fixture.ConsoleComplogPath, BasicAnalyzerHostOptions.Default);
+        var host = new BasicAnalyzerHostOptions(kind);
+        using var reader = SolutionReader.Create(Fixture.ConsoleComplogPath, host);
         var workspace = new AdhocWorkspace();
         var solution = workspace.AddSolution(reader.ReadSolutionInfo());
         var project = solution.Projects.Single();
         Assert.NotEmpty(project.AnalyzerReferences);
         var docs = await project.GetSourceGeneratedDocumentsAsync();
         var doc = docs.First(x => x.Name == "RegexGenerator.g.cs");
-        Assert.NotNull(doc);
-    }
-
-    [Fact]
-    public void DocumentsHaveGeneratedTextWithoutAnalyzers()
-    {
-        using var reader = SolutionReader.Create(Fixture.ConsoleComplogPath, BasicAnalyzerHostOptions.None);
-        var workspace = new AdhocWorkspace();
-        var solution = workspace.AddSolution(reader.ReadSolutionInfo());
-        var project = solution.Projects.Single();
-        Assert.Empty(project.AnalyzerReferences);
-        var doc = project.Documents.First(x => x.Name == "RegexGenerator.g.cs");
         Assert.NotNull(doc);
     }
 }

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -27,6 +27,7 @@ public abstract class TestBase : IDisposable
 
     public void Dispose()
     {
+        TestOutputHelper.WriteLine("Deleting temp directory");
         Root.Dispose();
     }
 

--- a/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
+++ b/src/Basic.CompilerLog.Util/Basic.CompilerLog.Util.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Packable>true</Packable>
+    <NoWarn>$(NoWarn);RS2008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
+++ b/src/Basic.CompilerLog.Util/BasicAnalyzerHost.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.ComponentModel;
+using System.Diagnostics;
 
 #if NETCOREAPP
 using System.Runtime.Loader;
@@ -117,9 +118,13 @@ public enum BasicAnalyzerKind
     OnDisk = 2,
 
     /// <summary>
-    /// Analyzers and generators are not loaded at all. The original generated files 
-    /// will be loaded directly into the resulting <see cref="Compilation" />.
+    /// Analyzers and generators from the original are not loaded at all. In the case 
+    /// the original build had generated files they will be added through an in 
+    /// memory analyzer that just adds them directly.
     /// </summary>
+    /// <remarks>
+    /// This option avoids loading third party analyzers and generators.
+    /// </remarks>
     None = 3,
 }
 

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -576,7 +576,7 @@ public sealed class CompilerLogReader : IDisposable
         {
             BasicAnalyzerKind.OnDisk => BasicAnalyzerHostOnDisk.Create(this, analyzers, BasicAnalyzerHostOptions),
             BasicAnalyzerKind.InMemory => BasicAnalyzerHostInMemory.Create(this, analyzers, BasicAnalyzerHostOptions),
-            BasicAnalyzerKind.None => new BasicAnalyzerHostNone(ReadGeneratedSourceTexts()),
+            BasicAnalyzerKind.None => new BasicAnalyzerHostNone(rawCompilationData.ReadGeneratedFiles, ReadGeneratedSourceTexts()),
             _ => throw new InvalidOperationException()
         };
 
@@ -603,6 +603,8 @@ public sealed class CompilerLogReader : IDisposable
                 {
                     builder.AppendLine(tuple.ContentHash);
                 }
+
+                builder.AppendLine(rawCompilationData.ReadGeneratedFiles.ToString());
             }
 
             return builder.ToString();

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -18,48 +18,6 @@ namespace Basic.CompilerLog.Util;
 /// </summary>
 public sealed class ExportUtil
 {
-    /// <summary>
-    /// Abstraction for getting new file paths for original paths in the compilation.
-    /// </summary>
-    private sealed class ResilientDirectory
-    {
-        /// <summary>
-        /// Content can exist outside the cone of the original project tree. That content 
-        /// is mapped, by original directory name, to a new directory in the output. This
-        /// holds the map from the old directory to the new one.
-        /// </summary>
-        private Dictionary<string, string> _map = new(PathUtil.Comparer);
-
-        internal string DirectoryPath { get; }
-
-        internal ResilientDirectory(string path)
-        {
-            DirectoryPath = path;
-            Directory.CreateDirectory(DirectoryPath);
-        }
-
-        internal string GetNewFilePath(string originalFilePath)
-        {
-            var key = Path.GetDirectoryName(originalFilePath)!;
-            if (!_map.TryGetValue(key, out var dirPath))
-            {
-                dirPath = Path.Combine(DirectoryPath, $"group{_map.Count}");
-                Directory.CreateDirectory(dirPath);
-                _map[key] = dirPath;
-            }
-
-            return Path.Combine(dirPath, Path.GetFileName(originalFilePath));
-        }
-
-        internal string WriteContent(string originalFilePath, Stream stream)
-        {
-            var newFilePath = GetNewFilePath(originalFilePath);
-            using var fileStream = new FileStream(newFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-            stream.CopyTo(fileStream);
-            return newFilePath;
-        }
-    }
-
     private sealed class ContentBuilder
     {
         internal string DestinationDirectory { get; }
@@ -84,7 +42,7 @@ public sealed class ExportUtil
             MiscDirectory = new(Path.Combine(destinationDirectory, "misc"));
             GeneratedCodeDirectory = new(Path.Combine(destinationDirectory, "generated"));
             AnalyzerDirectory = new(Path.Combine(destinationDirectory, "analyzers"));
-            BuildOutput = new(Path.Combine(destinationDirectory, "output"));
+            BuildOutput = new(Path.Combine(destinationDirectory, "output"), flatten: true);
             Directory.CreateDirectory(SourceDirectory);
             Directory.CreateDirectory(EmbeddedResourceDirectory);
         }

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
@@ -1,22 +1,77 @@
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Basic.CompilerLog.Util.Impl;
 
 /// <summary>
-/// This is a per-compilation analyzer assembly loader that can be used to produce 
-/// <see cref="AnalyzerFileReference"/> instances
+/// This is the analyzer host which doesn't actually run generators / analyzers. Instead it
+/// uses the source texts that were generated at the original build time.
 /// </summary>
 internal sealed class BasicAnalyzerHostNone : BasicAnalyzerHost
 {
-    public BasicAnalyzerHostNone()
-        : base(BasicAnalyzerKind.None, ImmutableArray<AnalyzerReference>.Empty)
-    {
+    internal ImmutableArray<(SourceText SourceText, string Path)> GeneratedSourceTexts { get; }
 
+    internal BasicAnalyzerHostNone(ImmutableArray<(SourceText SourceText, string Path)> generatedSourceTexts)
+        : base(BasicAnalyzerKind.None, CreateAnalyzerReferences(generatedSourceTexts))
+    {
+        GeneratedSourceTexts = generatedSourceTexts;
     }
 
     protected override void DisposeCore()
     {
         // Do nothing
     }
+
+    private static ImmutableArray<AnalyzerReference> CreateAnalyzerReferences(ImmutableArray<(SourceText SourceText, string Path)> generatedSourceTexts)
+    {
+        if (generatedSourceTexts.Length == 0)
+        {
+            return ImmutableArray<AnalyzerReference>.Empty;
+        }
+
+        return ImmutableArray.Create<AnalyzerReference>(new NoneReference(generatedSourceTexts));
+    }
 }
+
+file sealed class NoneReference : AnalyzerReference, ISourceGenerator
+{
+    internal ImmutableArray<(SourceText SourceText, string Path)> GeneratedSourceTexts { get; }
+    public override object Id { get; } = Guid.NewGuid();
+    public override string? FullPath => null;
+
+    internal NoneReference(ImmutableArray<(SourceText SourceText, string Path)> generatedSourceTexts)
+    {
+        GeneratedSourceTexts = generatedSourceTexts;
+    }
+
+    public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) =>
+        ImmutableArray<DiagnosticAnalyzer>.Empty;
+
+    public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() =>
+        ImmutableArray<DiagnosticAnalyzer>.Empty;
+
+    public override ImmutableArray<ISourceGenerator> GetGenerators(string? language) => 
+        ImmutableArray.Create<ISourceGenerator>(this);
+
+    public override ImmutableArray<ISourceGenerator> GetGeneratorsForAllLanguages() =>
+        ImmutableArray.Create<ISourceGenerator>(this);
+
+    public override string ToString() => $"None";
+
+    public void Initialize(GeneratorInitializationContext context)
+    {
+        
+    }
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        // TODO: this is wrong, need correct names
+        foreach (var (sourceText, filePath) in GeneratedSourceTexts)
+        {
+            context.AddSource(Path.GetFileName(filePath), sourceText);
+        }
+    }
+}
+

--- a/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
+++ b/src/Basic.CompilerLog.Util/Impl/BasicAnalyzerHostNone.cs
@@ -84,10 +84,20 @@ file sealed class NoneReference : AnalyzerReference, ISourceGenerator
                 Location.None));
         }
 
-        // TODO: this is wrong, need correct names
+        // The biggest challenge with adding names here is replicating the original 
+        // hint name. There is no way to definitively recover the original name hence we 
+        // have to go with just keeping the file name that was added then doing some basic
+        // counting to keep the name unique. 
+        var set = new HashSet<string>(PathUtil.Comparer);
         foreach (var (sourceText, filePath) in GeneratedSourceTexts)
         {
-            context.AddSource(Path.GetFileName(filePath), sourceText);
+            var fileName = Path.GetFileName(filePath);
+            if (!set.Add(fileName))
+            {
+                fileName = Path.Combine(set.Count.ToString(), fileName);
+            }
+
+            context.AddSource(fileName, sourceText);
         }
     }
 }

--- a/src/Basic.CompilerLog.Util/RawCompilationData.cs
+++ b/src/Basic.CompilerLog.Util/RawCompilationData.cs
@@ -73,17 +73,27 @@ internal sealed class RawCompilationData
     internal List<(string FilePath, string ContentHash, RawContentKind Kind)> Contents { get; }
     internal List<RawResourceData> Resources { get; }
 
+    /// <summary>
+    /// This is true when the generated files were successfully read from the original 
+    /// compilation. This can be true when there are no generated files. A successful read
+    /// for example happens on a compilation where there are no analyzers (successfully 
+    /// read zero files)
+    /// </summary>
+    internal bool ReadGeneratedFiles { get; }
+
     internal RawCompilationData(
         CommandLineArguments arguments,
         List<RawReferenceData> references,
         List<RawAnalyzerData> analyzers,
         List<(string FilePath, string ContentHash, RawContentKind Kind)> contents,
-        List<RawResourceData> resources)
+        List<RawResourceData> resources,
+        bool readGeneratedFiles)
     {
         Arguments = arguments;
         References = references;
         Analyzers = analyzers;
         Contents = contents;
         Resources = resources;
+        ReadGeneratedFiles = readGeneratedFiles;
     }
 }

--- a/src/Basic.CompilerLog.Util/ResilientDirectory.cs
+++ b/src/Basic.CompilerLog.Util/ResilientDirectory.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Basic.CompilerLog.Util;
+
+/// <summary>
+/// Abstraction for getting new file paths for original paths in the compilation.
+/// </summary>
+internal sealed class ResilientDirectory
+{
+    /// <summary>
+    /// Content can exist outside the cone of the original project tree. That content 
+    /// is mapped, by original directory name, to a new directory in the output. This
+    /// holds the map from the old directory to the new one.
+    /// </summary>
+    private Dictionary<string, string> _map = new(PathUtil.Comparer);
+
+    /// <summary>
+    /// When doing flattening this holds the map of file name that was flattened to the 
+    /// path that it was flattened from.
+    /// </summary>
+    private Dictionary<string, string>? _flattenedMap;
+
+    internal string DirectoryPath { get; }
+
+    /// <summary>
+    /// When true will attempt to flatten the directory structure by writing files
+    /// directly to the directory when possible.
+    /// </summary>
+    internal bool Flatten => _flattenedMap is not null;
+
+    internal ResilientDirectory(string path, bool flatten = false)
+    {
+        DirectoryPath = path;
+        Directory.CreateDirectory(DirectoryPath);
+        if (flatten)
+        {
+            _flattenedMap = new(PathUtil.Comparer);
+        }
+    }
+
+    internal string GetNewFilePath(string originalFilePath)
+    {
+        var fileName = Path.GetFileName(originalFilePath);
+        if (_flattenedMap is not null)
+        {
+            if (!_flattenedMap.TryGetValue(fileName, out var sourcePath) ||
+                PathUtil.Comparer.Equals(sourcePath, originalFilePath))
+            {
+                _flattenedMap[fileName] = originalFilePath;
+                return Path.Combine(DirectoryPath, fileName);
+            }
+        }
+
+        var key = Path.GetDirectoryName(originalFilePath)!;
+        if (!_map.TryGetValue(key, out var dirPath))
+        {
+            dirPath = Path.Combine(DirectoryPath, $"group{_map.Count}");
+            Directory.CreateDirectory(dirPath);
+            _map[key] = dirPath;
+        }
+
+        return Path.Combine(dirPath, fileName);
+    }
+
+    internal string WriteContent(string originalFilePath, Stream stream)
+    {
+        var newFilePath = GetNewFilePath(originalFilePath);
+        using var fileStream = new FileStream(newFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        stream.CopyTo(fileStream);
+        return newFilePath;
+    }
+}
+

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -80,12 +81,7 @@ public sealed class SolutionReader : IDisposable
                     Add(documents);
                     break;
                 case RawContentKind.GeneratedText:
-                    // If we're not loading analyzers then we need to put the generated text into the 
-                    // project
-                    if (Reader.BasicAnalyzerHostOptions.Kind == BasicAnalyzerKind.None)
-                    {
-                        Add(documents);
-                    }
+                    // Handled when creating analyzer host.
                     break;
                 case RawContentKind.AdditionalText:
                     Add(additionalDocuments);
@@ -122,7 +118,7 @@ public sealed class SolutionReader : IDisposable
         var projectReferences = new List<ProjectReference>();
 
         var referenceList = Reader.GetMetadataReferences(FilterToUnique(rawCompilationData.References));
-        var analyzers = Reader.ReadAnalyzers(rawCompilationData.Analyzers);
+        var analyzers = Reader.ReadAnalyzers(rawCompilationData);
         var projectInfo = ProjectInfo.Create(
             projectId,
             VersionStamp,

--- a/src/Basic.CompilerLog/FilterOptionSet.cs
+++ b/src/Basic.CompilerLog/FilterOptionSet.cs
@@ -7,15 +7,24 @@ internal sealed class FilterOptionSet : OptionSet
     internal bool IncludeAllKinds { get; set; }
     internal string? ProjectName { get; set; }
     internal bool Help { get; set; }
+    internal bool UseNoneHost { get; set; }
 
-    internal FilterOptionSet()
+    internal FilterOptionSet(bool includeNoneHost = false)
     {
         Add("include", "include all compilation kinds", i => { if (i != null) IncludeAllKinds = true; });
         Add("targetframework=", "", TargetFrameworks.Add, hidden: true);
         Add("framework=", "include only compilations for the target framework (allows multiple)", TargetFrameworks.Add);
         Add("n|projectName=", "include only compilations with the project name", (string n) => ProjectName = n);
         Add("h|help", "print help", h => { if (h != null) Help = true; });
+
+        if (includeNoneHost)
+        {
+            Add("none", "do not use original analyzers / generators", n => {  if (n != null) UseNoneHost = true; });
+        }
     }
+
+    internal BasicAnalyzerHostOptions? CreateHostOptions() =>
+        UseNoneHost ? BasicAnalyzerHostOptions.None : null;
 
     internal bool FilterCompilerCalls(CompilerCall compilerCall)
     {

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -386,7 +386,7 @@ int RunResponseFile(IEnumerable<string> args)
 int RunEmit(IEnumerable<string> args, CancellationToken cancellationToken)
 {
     var baseOutputPath = "";
-    var options = new FilterOptionSet()
+    var options = new FilterOptionSet(includeNoneHost: true)
     {
         { "o|out=", "path to output binaries to", o => baseOutputPath = o },
     };
@@ -452,7 +452,7 @@ int RunEmit(IEnumerable<string> args, CancellationToken cancellationToken)
 int RunDiagnostics(IEnumerable<string> args)
 {
     var severity = DiagnosticSeverity.Warning;
-    var options = new FilterOptionSet()
+    var options = new FilterOptionSet(includeNoneHost: true)
     {
         { "severity", "minimum severity to display (default Warning)", (DiagnosticSeverity s) => severity = s },
     };

--- a/src/Scratch/Benchmarks.cs
+++ b/src/Scratch/Benchmarks.cs
@@ -62,7 +62,7 @@ public class CompilerBenchmark
     public void LoadAnalyzers()
     {
         using var reader = CompilerLogReader.Create(CompilerLogPath, options: new BasicAnalyzerHostOptions(Kind));
-        var analyzers = reader.ReadAnalyzers(reader.ReadRawCompilationData(0).Item2.Analyzers);
+        var analyzers = reader.ReadAnalyzers(reader.ReadRawCompilationData(0).Item2);
         foreach (var analyzer in analyzers.AnalyzerReferences)
         {
             _ = analyzer.GetAnalyzersForAllLanguages();

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,4 @@
 make sure create is displaying diagnostics
 feed through the host to other commands
-be better about when None can be used
-make sure generated files only appear after getting generators
+X be better about when None can be used
+X make sure generated files only appear after getting generators

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,4 @@
+make sure create is displaying diagnostics
+feed through the host to other commands
+be better about when None can be used
+make sure generated files only appear after getting generators

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,0 @@
-make sure create is displaying diagnostics
-feed through the host to other commands
-X be better about when None can be used
-X make sure generated files only appear after getting generators


### PR DESCRIPTION
This work is the result of investigating issue #49 and causes the following changes to how the `None` analyzer host works. 

1. The compiler log now records whether or not generated files were able to be read. This does not mean there are generated files, just that the log creation was able to successfully probe for them. This will be false when a build failed, native PDBs are used, etc ... 
2. The reader now uses an in memory source generator to add back the generated files. That means every host has to go through the `CompilationData.GetCompilationAfterGenerators` code path. This makes consumption uniform for all the analyzer host kinds. 
3. When (1) above fails then `GetCompilationAfterGenerators` will have a diagnostic stating this. That means consumers won't silently run into this problem.
4. Threaded through the ability to use the `None` analyzer host on a few of the command line options. 