### PR TITLE
Round out the line directive support

### DIFF
--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -123,18 +123,7 @@ public sealed class CompilerLogFixture : IDisposable
         ConsoleWithLineAndEmbedComplogPath = WithBuild("console-with-line-and-embed.complog", void (string scratchPath) =>
         {
             RunDotnetCommand($"new console --name console --output .", scratchPath);
-            var projectFileContent = """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <OutputType>Exe</OutputType>
-                    <TargetFramework>net7.0</TargetFramework>
-                    <ImplicitUsings>enable</ImplicitUsings>
-                    <Nullable>enable</Nullable>
-                    <EmbedAllSources>true</EmbedAllSources>
-                  </PropertyGroup>
-                </Project>
-                """;
-            File.WriteAllText(Path.Combine(scratchPath, "console.csproj"), projectFileContent, TestBase.DefaultEncoding);
+            DotnetUtil.AddProjectProperty("<EmbedAllSources>true</EmbedAllSources>", scratchPath);
             var extra = """
                 using System;
                 using System.Text.RegularExpressions;
@@ -150,17 +139,7 @@ public sealed class CompilerLogFixture : IDisposable
 
         ClassLibComplogPath = WithBuild("classlib.complog", void (string scratchPath) =>
         {
-            RunDotnetCommand($"new classlib --name classlib --output .", scratchPath);
-            var projectFileContent = """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                    <ImplicitUsings>enable</ImplicitUsings>
-                    <Nullable>enable</Nullable>
-                  </PropertyGroup>
-                </Project>
-                """;
-            File.WriteAllText(Path.Combine(scratchPath, "classlib.csproj"), projectFileContent, TestBase.DefaultEncoding);
+            RunDotnetCommand($"new classlib --name classlib --output . --framework net7.0", scratchPath);
             var program = """
                 using System;
                 using System.Text.RegularExpressions;
@@ -178,17 +157,7 @@ public sealed class CompilerLogFixture : IDisposable
         {
             RunDotnetCommand($"new classlib --name classlibsigned --output .", scratchPath);
             var keyFilePath = Path.Combine(scratchPath, "Key.snk");
-            var projectFileContent = $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net7.0</TargetFramework>
-                    <ImplicitUsings>enable</ImplicitUsings>
-                    <Nullable>enable</Nullable>
-                    <KeyOriginatorFile>{keyFilePath}</KeyOriginatorFile>
-                  </PropertyGroup>
-                </Project>
-                """;
-            File.WriteAllText(Path.Combine(scratchPath, "classlibsigned.csproj"), projectFileContent, TestBase.DefaultEncoding);
+            DotnetUtil.AddProjectProperty($"<KeyOriginatorFile>{keyFilePath}</KeyOriginatorFile>", scratchPath);
             File.WriteAllBytes(keyFilePath, ResourceLoader.GetResourceBlob("Key.snk"));
             var program = """
                 using System;

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -15,33 +15,36 @@ namespace Basic.CompilerLog.UnitTests;
 
 public sealed class CompilerLogFixture : IDisposable
 {
+    private readonly List<Lazy<string>> _allCompLogs = new();
+
+    /// <summary>
+    /// Storage directory for all the generated artifacts and scatch directories
+    /// </summary>
     internal string StorageDirectory { get; }
-    
+
     /// <summary>
     /// Directory that holds the log files
     /// </summary>
     internal string ComplogDirectory { get; }
 
-    internal string ConsoleComplogPath { get; }
+    internal Lazy<string> ConsoleComplogPath { get; }
 
-    internal string ConsoleNoGeneratorComplogPath { get; }
+    internal Lazy<string> ConsoleNoGeneratorComplogPath { get; }
 
-    internal string ConsoleWithLineComplogPath { get; }
+    internal Lazy<string> ConsoleWithLineComplogPath { get; }
 
-    internal string ConsoleWithLineAndEmbedComplogPath { get; }
+    internal Lazy<string> ConsoleWithLineAndEmbedComplogPath { get; }
 
-    internal string ClassLibComplogPath { get; }
+    internal Lazy<string> ClassLibComplogPath { get; }
 
-    internal string ClassLibSignedComplogPath { get; }
+    internal Lazy<string> ClassLibSignedComplogPath { get; }
 
     /// <summary>
     /// A multi-targeted class library
     /// </summary>
-    internal string ClassLibMultiComplogPath { get; }
+    internal Lazy<string> ClassLibMultiComplogPath { get; }
 
-    internal string? WpfAppComplogPath { get; }
-
-    internal IEnumerable<string> AllComplogs { get; }
+    internal Lazy<string>? WpfAppComplogPath { get; }
 
     /// <summary>
     /// Constructor for the primary fixture. To get actual diagnostic messages into the output 
@@ -64,8 +67,7 @@ public sealed class CompilerLogFixture : IDisposable
             Assert.True(result.Succeeded);
         }
 
-        var allCompLogs = new List<string>();
-        ConsoleComplogPath = WithBuild("console.complog", string (string scratchPath) =>
+        ConsoleComplogPath = WithBuild("console.complog", void (string scratchPath) =>
         {
             RunDotnetCommand($"new console --name console --output .", scratchPath);
             var projectFileContent = """
@@ -93,17 +95,15 @@ public sealed class CompilerLogFixture : IDisposable
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Program.cs"), program, TestBase.DefaultEncoding);
             RunDotnetCommand("build -bl", scratchPath);
-            return Path.Combine(scratchPath, "msbuild.binlog");
         });
 
-        ConsoleNoGeneratorComplogPath = WithBuild("console-no-generator.complog", string (string scratchPath) =>
+        ConsoleNoGeneratorComplogPath = WithBuild("console-no-generator.complog", void (string scratchPath) =>
         {
             RunDotnetCommand($"new console --name example-no-generator --output .", scratchPath);
             RunDotnetCommand("build -bl", scratchPath);
-            return Path.Combine(scratchPath, "msbuild.binlog");
         });
         
-        ConsoleWithLineComplogPath = WithBuild("console-with-line.complog", string (string scratchPath) =>
+        ConsoleWithLineComplogPath = WithBuild("console-with-line.complog", void (string scratchPath) =>
         {
             RunDotnetCommand($"new console --name console --output .", scratchPath);
             var extra = """
@@ -116,10 +116,9 @@ public sealed class CompilerLogFixture : IDisposable
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Extra.cs"), extra, TestBase.DefaultEncoding);
             RunDotnetCommand("build -bl", scratchPath);
-            return Path.Combine(scratchPath, "msbuild.binlog");
         });
 
-        ConsoleWithLineAndEmbedComplogPath = WithBuild("console-with-line-and-embed.complog", string (string scratchPath) =>
+        ConsoleWithLineAndEmbedComplogPath = WithBuild("console-with-line-and-embed.complog", void (string scratchPath) =>
         {
             RunDotnetCommand($"new console --name console --output .", scratchPath);
             var projectFileContent = """
@@ -145,10 +144,9 @@ public sealed class CompilerLogFixture : IDisposable
             File.WriteAllText(Path.Combine(scratchPath, "Extra.cs"), extra, TestBase.DefaultEncoding);
             File.WriteAllText(Path.Combine(scratchPath, "line.txt"), "this is content", TestBase.DefaultEncoding);
             RunDotnetCommand("build -bl", scratchPath);
-            return Path.Combine(scratchPath, "msbuild.binlog");
         });
 
-        ClassLibComplogPath = WithBuild("classlib.complog", string (string scratchPath) =>
+        ClassLibComplogPath = WithBuild("classlib.complog", void (string scratchPath) =>
         {
             RunDotnetCommand($"new classlib --name classlib --output .", scratchPath);
             var projectFileContent = """
@@ -172,10 +170,9 @@ public sealed class CompilerLogFixture : IDisposable
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Class1.cs"), program, TestBase.DefaultEncoding);
             RunDotnetCommand("build -bl", scratchPath);
-            return Path.Combine(scratchPath, "msbuild.binlog");
         });
 
-        ClassLibSignedComplogPath = WithBuild("classlibsigned.complog", string (string scratchPath) =>
+        ClassLibSignedComplogPath = WithBuild("classlibsigned.complog", void (string scratchPath) =>
         {
             RunDotnetCommand($"new classlib --name classlibsigned --output .", scratchPath);
             var keyFilePath = Path.Combine(scratchPath, "Key.snk");
@@ -202,10 +199,9 @@ public sealed class CompilerLogFixture : IDisposable
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Class1.cs"), program, TestBase.DefaultEncoding);
             RunDotnetCommand("build -bl", scratchPath);
-            return Path.Combine(scratchPath, "msbuild.binlog");
         });
 
-        ClassLibMultiComplogPath = WithBuild("classlibmulti.complog", string (string scratchPath) =>
+        ClassLibMultiComplogPath = WithBuild("classlibmulti.complog", void (string scratchPath) =>
         {
             RunDotnetCommand($"new classlib --name classlibmulti --output .", scratchPath);
             var projectFileContent = """
@@ -228,43 +224,48 @@ public sealed class CompilerLogFixture : IDisposable
                 """;
             File.WriteAllText(Path.Combine(scratchPath, "Class 1.cs"), program, TestBase.DefaultEncoding);
             RunDotnetCommand("build -bl", scratchPath);
-            return Path.Combine(scratchPath, "msbuild.binlog");
         });
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            WpfAppComplogPath = WithBuild("wpfapp.complog", string (string scratchPath) =>
+            WpfAppComplogPath = WithBuild("wpfapp.complog", void (string scratchPath) =>
             {
                 RunDotnetCommand("new wpf --name wpfapp --output .", scratchPath);
                 RunDotnetCommand("build -bl", scratchPath);
-                return Path.Combine(scratchPath, "msbuild.binlog");
             });
         }
 
-        AllComplogs = allCompLogs;
-        string WithBuild(string name, Func<string, string> action)
+        Lazy<string> WithBuild(string name, Action<string> action)
         {
-            try
+            var lazy = new Lazy<string>(() =>
             {
-                var scratchPath = Path.Combine(StorageDirectory, "scratch dir", Guid.NewGuid().ToString("N"));
-                Directory.CreateDirectory(scratchPath);
-                RunDotnetCommand("new globaljson --sdk-version 7.0.400", scratchPath);
-                var binlogFilePath = action(scratchPath);
-                Assert.True(File.Exists(binlogFilePath));
-                var complogFilePath = Path.Combine(ComplogDirectory, name);
-                var diagnostics = CompilerLogUtil.ConvertBinaryLog(binlogFilePath, complogFilePath);
-                Assert.Empty(diagnostics);
-                Directory.Delete(scratchPath, recursive: true);
-                allCompLogs.Add(complogFilePath);
-                return complogFilePath;
-            }
-            catch (Exception ex)
-            {
-                messageSink.OnMessage(new DiagnosticMessage(diagnosticBuilder.ToString()));
-                throw new Exception($"Cannot generate compiler log {name}", ex);
-            }
+                try
+                {
+                    var scratchPath = Path.Combine(StorageDirectory, "scratch dir", Guid.NewGuid().ToString("N"));
+                    Directory.CreateDirectory(scratchPath);
+                    RunDotnetCommand("new globaljson --sdk-version 7.0.400", scratchPath);
+                    action(scratchPath);
+                    var binlogFilePath = Path.Combine(scratchPath, "msbuild.binlog");
+                    Assert.True(File.Exists(binlogFilePath));
+                    var complogFilePath = Path.Combine(ComplogDirectory, name);
+                    var diagnostics = CompilerLogUtil.ConvertBinaryLog(binlogFilePath, complogFilePath);
+                    Assert.Empty(diagnostics);
+                    Directory.Delete(scratchPath, recursive: true);
+                    return complogFilePath;
+                }
+                catch (Exception ex)
+                {
+                    messageSink.OnMessage(new DiagnosticMessage(diagnosticBuilder.ToString()));
+                    throw new Exception($"Cannot generate compiler log {name}", ex);
+                }
+            });
+
+            _allCompLogs.Add(lazy);
+            return lazy;
         }
     }
+
+    public IEnumerable<string> GetAllCompLogs() => _allCompLogs.Select(x => x.Value);
 
     public void Dispose()
     {

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogFixture.cs
@@ -2,6 +2,7 @@
 using Microsoft.Build.Framework;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -15,7 +16,7 @@ namespace Basic.CompilerLog.UnitTests;
 
 public sealed class CompilerLogFixture : IDisposable
 {
-    private readonly List<Lazy<string>> _allCompLogs = new();
+    private readonly ImmutableArray<Lazy<string>> _allCompLogs;
 
     /// <summary>
     /// Storage directory for all the generated artifacts and scatch directories
@@ -67,6 +68,7 @@ public sealed class CompilerLogFixture : IDisposable
             Assert.True(result.Succeeded);
         }
 
+        var builder = ImmutableArray.CreateBuilder<Lazy<string>>();
         ConsoleComplogPath = WithBuild("console.complog", void (string scratchPath) =>
         {
             RunDotnetCommand($"new console --name console --output .", scratchPath);
@@ -235,6 +237,7 @@ public sealed class CompilerLogFixture : IDisposable
             });
         }
 
+        _allCompLogs = builder.ToImmutable();
         Lazy<string> WithBuild(string name, Action<string> action)
         {
             var lazy = new Lazy<string>(() =>
@@ -260,7 +263,7 @@ public sealed class CompilerLogFixture : IDisposable
                 }
             });
 
-            _allCompLogs.Add(lazy);
+            builder.Add(lazy);
             return lazy;
         }
     }

--- a/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/CompilerLogReaderTests.cs
@@ -104,7 +104,7 @@ public sealed class CompilerLogReaderTests : TestBase
     public void KeyFileDefault()
     {
         var keyBytes = ResourceLoader.GetResourceBlob("Key.snk");
-        using var reader = CompilerLogReader.Create(Fixture.ClassLibSignedComplogPath);
+        using var reader = CompilerLogReader.Create(Fixture.ClassLibSignedComplogPath.Value);
         var data = reader.ReadCompilationData(0);
 
         Assert.NotNull(data.CompilationOptions.CryptoKeyFile);
@@ -121,7 +121,7 @@ public sealed class CompilerLogReaderTests : TestBase
         using var state = new CompilerLogState(tempDir.DirectoryPath);
 
         var keyBytes = ResourceLoader.GetResourceBlob("Key.snk");
-        using var reader = CompilerLogReader.Create(Fixture.ClassLibSignedComplogPath, state: state);
+        using var reader = CompilerLogReader.Create(Fixture.ClassLibSignedComplogPath.Value, state: state);
         var data = reader.ReadCompilationData(0);
 
         Assert.NotNull(data.CompilationOptions.CryptoKeyFile);
@@ -150,7 +150,7 @@ public sealed class CompilerLogReaderTests : TestBase
             any = true;
 
             var options = new BasicAnalyzerHostOptions(kind);
-            using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath, options: options);
+            using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value, options: options);
             var data = reader.ReadCompilationData(0);
             var compilation = data.GetCompilationAfterGenerators(out var diagnostics);
             Assert.Empty(diagnostics);
@@ -181,7 +181,7 @@ public sealed class CompilerLogReaderTests : TestBase
         }
 
         var options = new BasicAnalyzerHostOptions(kind, cacheable: true);
-        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath, options: options);
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value, options: options);
         var data = reader.ReadRawCompilationData(0).Item2;
 
         var host1 = reader.ReadAnalyzers(data);
@@ -203,7 +203,7 @@ public sealed class CompilerLogReaderTests : TestBase
         }
 
         var options = new BasicAnalyzerHostOptions(kind, cacheable: true);
-        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath, options: options);
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value, options: options);
         var data = reader.ReadCompilationData(0);
         Assert.False(data.BasicAnalyzerHost.IsDisposed);
         reader.Dispose();
@@ -213,7 +213,7 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void ProjectSingleTarget()
     {
-        using var reader = CompilerLogReader.Create(Fixture.ClassLibComplogPath);
+        using var reader = CompilerLogReader.Create(Fixture.ClassLibComplogPath.Value);
         var list = reader.ReadAllCompilationData();
         Assert.Single(list);
         Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net7.0"));
@@ -222,7 +222,7 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void ProjectMultiTarget()
     {
-        using var reader = CompilerLogReader.Create(Fixture.ClassLibMultiComplogPath);
+        using var reader = CompilerLogReader.Create(Fixture.ClassLibMultiComplogPath.Value);
         var list = reader.ReadAllCompilationData();
         Assert.Equal(2, list.Count);
         Assert.NotNull(list.Single(x => x.CompilerCall.TargetFramework == "net6.0"));
@@ -232,8 +232,9 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void EmitToDisk()
     {
-        Assert.NotEmpty(Fixture.AllComplogs);
-        foreach (var complogPath in Fixture.AllComplogs)
+        var all = Fixture.GetAllCompLogs();
+        Assert.NotEmpty(all);
+        foreach (var complogPath in all)
         {
             TestOutputHelper.WriteLine(complogPath);
             using var reader = CompilerLogReader.Create(complogPath);
@@ -250,8 +251,9 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void EmitToMemory()
     {
-        Assert.NotEmpty(Fixture.AllComplogs);
-        foreach (var complogPath in Fixture.AllComplogs)
+        var all = Fixture.GetAllCompLogs();
+        Assert.NotEmpty(all);
+        foreach (var complogPath in all)
         {
             TestOutputHelper.WriteLine(complogPath);
             using var reader = CompilerLogReader.Create(complogPath);
@@ -267,7 +269,7 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void NoneHostGeneratedFilesInRaw()
     {
-        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath, BasicAnalyzerHostOptions.None);
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value, BasicAnalyzerHostOptions.None);
         var (_, data) = reader.ReadRawCompilationData(0);
         Assert.Equal(1, data.Contents.Count(x => x.Kind == RawContentKind.GeneratedText));
     }
@@ -275,7 +277,7 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void NoneHostGeneratedFilesShouldBeLast()
     {
-        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath, BasicAnalyzerHostOptions.None);
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value, BasicAnalyzerHostOptions.None);
         var data = reader.ReadCompilationData(0);
         var tree = data.GetCompilationAfterGenerators().SyntaxTrees.Last();
         var decls = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().ToList();
@@ -287,7 +289,7 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void NoneHostAddsFakeGeneratorForGeneratedSource()
     {
-        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath, BasicAnalyzerHostOptions.None);
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleComplogPath.Value, BasicAnalyzerHostOptions.None);
         var data = reader.ReadCompilationData(0);
         var compilation1 = data.Compilation;
         var compilation2 = data.GetCompilationAfterGenerators();
@@ -298,7 +300,7 @@ public sealed class CompilerLogReaderTests : TestBase
     [Fact]
     public void NoneHostAddsNoGeneratorIfNoGeneratedSource()
     {
-        using var reader = CompilerLogReader.Create(Fixture.ConsoleNoGeneratorComplogPath, BasicAnalyzerHostOptions.None);
+        using var reader = CompilerLogReader.Create(Fixture.ConsoleNoGeneratorComplogPath.Value, BasicAnalyzerHostOptions.None);
         var data = reader.ReadCompilationData(0);
         var compilation1 = data.Compilation;
         var compilation2 = data.GetCompilationAfterGenerators();
@@ -344,7 +346,7 @@ public sealed class CompilerLogReaderTests : TestBase
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             Assert.NotNull(Fixture.WpfAppComplogPath);
-            using var reader = CompilerLogReader.Create(Fixture.WpfAppComplogPath);
+            using var reader = CompilerLogReader.Create(Fixture.WpfAppComplogPath.Value);
             var list = reader.ReadAllCompilationData();
             Assert.Equal(2, list.Count);
             Assert.Equal(CompilerCallKind.WpfTemporaryCompile, list[0].Kind);

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -85,13 +85,13 @@ public sealed class ExportUtilTests : TestBase
     [Fact]
     public void Console()
     {
-        TestExport(Fixture.ConsoleComplogPath, 1);
+        TestExport(Fixture.ConsoleComplogPath.Value, 1);
     }
 
     [Fact]
     public void ClassLib()
     {
-        TestExport(Fixture.ClassLibComplogPath, 1);
+        TestExport(Fixture.ClassLibComplogPath.Value, 1);
     }
 
     /// <summary>
@@ -100,7 +100,7 @@ public sealed class ExportUtilTests : TestBase
     [Fact]
     public void GeneratedText()
     {
-        TestExport(Fixture.ConsoleComplogPath, 1, callback: tempPath =>
+        TestExport(Fixture.ConsoleComplogPath.Value, 1, callback: tempPath =>
         {
             var generatedPath = Path.Combine(tempPath, "generated");
             var files = Directory.GetFiles(generatedPath, "*.cs", SearchOption.AllDirectories);
@@ -115,7 +115,7 @@ public sealed class ExportUtilTests : TestBase
     [Fact]
     public void GeneratedTextExcludeAnalyzers()
     {
-        TestExport(Fixture.ConsoleComplogPath, 1, includeAnalyzers: false, callback: tempPath =>
+        TestExport(Fixture.ConsoleComplogPath.Value, 1, includeAnalyzers: false, callback: tempPath =>
         {
             var rspPath = Path.Combine(tempPath, "build.rsp");
             var foundPath = false;
@@ -296,7 +296,7 @@ public sealed class ExportUtilTests : TestBase
     [InlineData(false)]
     public void AllCompilerLogs(bool includeAnalyzers)
     {
-        foreach (var complogPath in Fixture.AllComplogs)
+        foreach (var complogPath in Fixture.GetAllCompLogs())
         {
             TestExport(complogPath, expectedCount: null, includeAnalyzers);
         }

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -60,7 +60,7 @@ public sealed class ExportUtilTests : TestBase
             var buildResult = RunBuildCmd(tempDir.DirectoryPath);
             TestOutputHelper.WriteLine(buildResult.StandardOut);
             TestOutputHelper.WriteLine(buildResult.StandardError);
-            Assert.True(buildResult.Succeeded);
+            Assert.True(buildResult.Succeeded, $"Cannot build {Path.GetFileName(compilerLogFilePath)}");
 
             // Ensure that full paths aren't getting written out to the RSP file. That makes the 
             // build non-xcopyable. 

--- a/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/ExportUtilTests.cs
@@ -24,7 +24,7 @@ public sealed class ExportUtilTests : TestBase
         Fixture = fixture;
     }
 
-    private void TestExport(int expectedCount, Action<string>? verifyExportCallback = null, Action? afterCreateCallback = null)
+    private void TestExport(int expectedCount, Action<string>? verifyExportCallback = null)
     {
         using var scratchDir = new TempDir("export test");
         var binlogFilePath = Path.Combine(RootDirectory, "msbuild.binlog");
@@ -35,7 +35,6 @@ public sealed class ExportUtilTests : TestBase
         // Now that we've converted to a compiler log delete all the original project code. This 
         // ensures our builds below don't succeed because old files are being referenced
         Root.EmptyDirectory();
-        afterCreateCallback?.Invoke();
 
         TestExport(compilerLogFilePath, expectedCount, verifyExportCallback: verifyExportCallback);
     }
@@ -281,7 +280,7 @@ public sealed class ExportUtilTests : TestBase
         TestExport(1);
     }
 
-    private void EmbedLineCore(string contentFilePath, Action? afterCreateCallback = null)
+    private void EmbedLineCore(string contentFilePath)
     {
         RunDotNet($"new console --name example --output .");
         AddProjectProperty("<EmbedAllSources>true</EmbedAllSources>");
@@ -290,7 +289,7 @@ public sealed class ExportUtilTests : TestBase
         #line 42 "{contentFilePath}"
         """);
         RunDotNet("build -bl");
-        TestExport(1, afterCreateCallback: afterCreateCallback);
+        TestExport(1);
     }
 
     [Fact]

--- a/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
+++ b/src/Basic.CompilerLog.UnitTests/SolutionReaderTests.cs
@@ -23,7 +23,7 @@ public sealed class SolutionReaderTests : TestBase
 
     private void LoadAllCore(BasicAnalyzerHostOptions options)
     {
-        foreach (var complogPath in Fixture.AllComplogs)
+        foreach (var complogPath in Fixture.GetAllCompLogs())
         {
             using var reader = SolutionReader.Create(complogPath, options);
             var workspace = new AdhocWorkspace();
@@ -46,7 +46,7 @@ public sealed class SolutionReaderTests : TestBase
     public async Task DocumentsHaveGeneratedTextWithAnalyzers(BasicAnalyzerKind kind)
     {
         var host = new BasicAnalyzerHostOptions(kind);
-        using var reader = SolutionReader.Create(Fixture.ConsoleComplogPath, host);
+        using var reader = SolutionReader.Create(Fixture.ConsoleComplogPath.Value, host);
         var workspace = new AdhocWorkspace();
         var solution = workspace.AddSolution(reader.ReadSolutionInfo());
         var project = solution.Projects.Single();

--- a/src/Basic.CompilerLog.UnitTests/TempDir.cs
+++ b/src/Basic.CompilerLog.UnitTests/TempDir.cs
@@ -23,7 +23,17 @@ internal sealed class TempDir : IDisposable
 
     public void Dispose()
     {
-        Directory.Delete(DirectoryPath, recursive: true);
+        if (Directory.Exists(DirectoryPath))
+        {
+            Directory.Delete(DirectoryPath, recursive: true);
+        }
+    }
+
+    public string NewFile(string fileName, string content)
+    {
+        var filePath = Path.Combine(DirectoryPath, fileName);
+        File.WriteAllText(filePath, content);
+        return filePath;
     }
 
     public void EmptyDirectory()

--- a/src/Basic.CompilerLog.UnitTests/TempDir.cs
+++ b/src/Basic.CompilerLog.UnitTests/TempDir.cs
@@ -36,6 +36,13 @@ internal sealed class TempDir : IDisposable
         return filePath;
     }
 
+    public string NewDirectory(string name)
+    {
+        var path = Path.Combine(DirectoryPath, name);
+        _ = Directory.CreateDirectory(path);
+        return path;
+    }
+
     public void EmptyDirectory()
     {
         var d = new DirectoryInfo(DirectoryPath);

--- a/src/Basic.CompilerLog.UnitTests/TestBase.cs
+++ b/src/Basic.CompilerLog.UnitTests/TestBase.cs
@@ -1,6 +1,7 @@
 ﻿using Basic.CompilerLog.Util;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -51,6 +52,11 @@ public abstract class TestBase : IDisposable
         TestOutputHelper.WriteLine(result.StandardOut);
         TestOutputHelper.WriteLine(result.StandardError);
         Assert.Equal(0, result.ExitCode);
+    }
+
+    protected void AddProjectProperty(string property, string? workingDirectory = null)
+    {
+        DotnetUtil.AddProjectProperty(property, workingDirectory ?? RootDirectory);
     }
 
     protected string GetBinaryLogFullPath(string? workingDirectory = null) =>

--- a/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogBuilder.cs
@@ -1,23 +1,15 @@
-﻿using Basic.CompilerLog.Util.Impl;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading.Tasks;
 using static Basic.CompilerLog.Util.CommonUtil;
 
 namespace Basic.CompilerLog.Util;
@@ -83,7 +75,7 @@ internal sealed class CompilerLogBuilder : IDisposable
             AddSources(compilationWriter, commandLineArguments);
             AddAdditionalTexts(compilationWriter, commandLineArguments);
             AddResources(compilationWriter, commandLineArguments);
-            AddedEmbeds(compilationWriter, commandLineArguments);
+            AddEmbeds(compilationWriter, commandLineArguments);
             AddContentIf("link", commandLineArguments.SourceLink);
             AddContentIf("ruleset", commandLineArguments.RuleSetPath);
             AddContentIf("appconfig", commandLineArguments.AppConfigPath);
@@ -455,7 +447,7 @@ internal sealed class CompilerLogBuilder : IDisposable
         }
     }
 
-    private void AddedEmbeds(StreamWriter compilationWriter, CommandLineArguments args)
+    private void AddEmbeds(StreamWriter compilationWriter, CommandLineArguments args)
     {
         foreach (var e in args.EmbeddedFiles)
         {

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -135,32 +135,32 @@ public sealed class CompilerLogReader : IDisposable
             : rawCompilationData.Resources.Select(x => x.ResourceDescription).ToList();
         List<EmbeddedText>? embeddedTexts = null;
 
-        foreach (var tuple in rawCompilationData.Contents)
+        foreach (var rawContent in rawCompilationData.Contents)
         {
-            switch (tuple.Kind)
+            switch (rawContent.Kind)
             {
                 case RawContentKind.SourceText:
-                    sourceTextList.Add((GetSourceText(tuple.ContentHash, hashAlgorithm), tuple.FilePath));
+                    sourceTextList.Add((GetSourceText(rawContent.ContentHash, hashAlgorithm), rawContent.FilePath));
                     break;
                 case RawContentKind.GeneratedText:
                     // Handled when creating the analyzer host
                     break;
                 case RawContentKind.AnalyzerConfig:
-                    analyzerConfigList.Add((GetSourceText(tuple.ContentHash, hashAlgorithm), tuple.FilePath));
+                    analyzerConfigList.Add((GetSourceText(rawContent.ContentHash, hashAlgorithm), rawContent.FilePath));
                     break;
                 case RawContentKind.AdditionalText:
                     additionalTextList.Add(new BasicAdditionalTextFile(
-                        tuple.FilePath,
-                        GetSourceText(tuple.ContentHash, hashAlgorithm)));
+                        rawContent.FilePath,
+                        GetSourceText(rawContent.ContentHash, hashAlgorithm)));
                     break;
                 case RawContentKind.CryptoKeyFile:
-                    HandleCryptoKeyFile(tuple.ContentHash);
+                    HandleCryptoKeyFile(rawContent.ContentHash);
                     break;
                 case RawContentKind.SourceLink:
-                    sourceLinkStream = GetStateAwareContentStream(tuple.ContentHash);
+                    sourceLinkStream = GetStateAwareContentStream(rawContent.ContentHash);
                     break;
                 case RawContentKind.Win32Resource:
-                    win32ResourceStream = GetStateAwareContentStream(tuple.ContentHash);
+                    win32ResourceStream = GetStateAwareContentStream(rawContent.ContentHash);
                     break;
                 case RawContentKind.Embed:
                 {
@@ -169,8 +169,8 @@ public sealed class CompilerLogReader : IDisposable
                         embeddedTexts = new List<EmbeddedText>();
                     }
 
-                    var sourceText = GetSourceText(tuple.ContentHash, hashAlgorithm, canBeEmbedded: true);
-                    var embeddedText = EmbeddedText.FromSource(tuple.FilePath, sourceText);
+                    var sourceText = GetSourceText(rawContent.ContentHash, hashAlgorithm, canBeEmbedded: true);
+                    var embeddedText = EmbeddedText.FromSource(rawContent.FilePath, sourceText);
                     embeddedTexts.Add(embeddedText);
                     break;
                 }
@@ -346,7 +346,7 @@ public sealed class CompilerLogReader : IDisposable
             : VisualBasicCommandLineParser.Default.Parse(compilerCall.Arguments, Path.GetDirectoryName(compilerCall.ProjectFilePath), sdkDirectory: null, additionalReferenceDirectories: null);
         var references = new List<RawReferenceData>();
         var analyzers = new List<RawAnalyzerData>();
-        var contents = new List<(string FilePath, string ContentHash, RawContentKind Kind)>();
+        var contents = new List<RawContent>();
         var resources = new List<RawResourceData>();
         var readGeneratedFiles = false;
 
@@ -455,7 +455,7 @@ public sealed class CompilerLogReader : IDisposable
         void ParseContent(string line, RawContentKind kind)
         {
             var items = line.Split(':', count: 3);
-            contents.Add((items[2], items[1], kind));
+            contents.Add(new(items[2], items[1], kind));
         }
 
         void ParseResource(string line)

--- a/src/Basic.CompilerLog.Util/CompilerLogReader.cs
+++ b/src/Basic.CompilerLog.Util/CompilerLogReader.cs
@@ -1,4 +1,5 @@
 ﻿using Basic.CompilerLog.Util.Impl;
+using Microsoft.Build.Logging.StructuredLogger;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -173,6 +174,11 @@ public sealed class CompilerLogReader : IDisposable
                     embeddedTexts.Add(embeddedText);
                     break;
                 }
+
+                // not exposed as #line embeds don't matter for most API usages, it's only used in 
+                // command line compiles
+                case RawContentKind.EmbedLine:
+                    break;
 
                 // not exposed yet
                 case RawContentKind.RuleSet:
@@ -372,6 +378,9 @@ public sealed class CompilerLogReader : IDisposable
                     break;
                 case "embed":
                     ParseContent(line, RawContentKind.Embed);
+                    break;
+                case "embedline":
+                    ParseContent(line, RawContentKind.EmbedLine);
                     break;
                 case "link":
                     ParseContent(line, RawContentKind.SourceLink);

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -133,7 +133,6 @@ public sealed class ExportUtil
         var builder = new ContentBuilder(destinationDir, compilerCall.ProjectFilePath);
 
         var commandLineList = new List<string>();
-        var pathMap = new List<string>();
         var data = Reader.ReadRawCompilationData(compilerCall);
         Directory.CreateDirectory(destinationDir);
         WriteGeneratedFiles();
@@ -337,9 +336,8 @@ public sealed class ExportUtil
         {
             foreach (var tuple in data.Contents.Where(x => x.Kind == RawContentKind.EmbedLine))
             {
-                // TODO: handle path map correctly here.
                 using var contentStream = Reader.GetContentStream(tuple.ContentHash);
-                _ = builder.WriteContent(tuple.FilePath, contentStream);
+                var newPath = builder.WriteContent(tuple.FilePath, contentStream);
             }
         }
 

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -133,6 +133,7 @@ public sealed class ExportUtil
         var builder = new ContentBuilder(destinationDir, compilerCall.ProjectFilePath);
 
         var commandLineList = new List<string>();
+        var pathMap = new List<string>();
         var data = Reader.ReadRawCompilationData(compilerCall);
         Directory.CreateDirectory(destinationDir);
         WriteGeneratedFiles();

--- a/src/Basic.CompilerLog.Util/ExportUtil.cs
+++ b/src/Basic.CompilerLog.Util/ExportUtil.cs
@@ -340,7 +340,6 @@ public sealed class ExportUtil
                 using var contentStream = Reader.GetContentStream(tuple.ContentHash);
                 _ = builder.WriteContent(tuple.FilePath, contentStream);
             }
-
         }
 
         void WriteResources()

--- a/src/Basic.CompilerLog.Util/RawCompilationData.cs
+++ b/src/Basic.CompilerLog.Util/RawCompilationData.cs
@@ -66,12 +66,31 @@ internal readonly struct RawResourceData
     }
 }
 
+internal readonly struct RawContent
+{
+    internal string FilePath { get; }
+    internal string ContentHash { get; }
+    internal RawContentKind Kind { get; }
+
+    internal RawContent(
+        string filePath,
+        string contentHash,
+        RawContentKind kind)
+    {
+        FilePath = filePath;
+        ContentHash = contentHash;
+        Kind = kind;
+    }
+
+    public override string ToString() => $"{Path.GetFileName(FilePath)} {Kind}";
+}
+
 internal sealed class RawCompilationData
 {
     internal CommandLineArguments Arguments { get; }
     internal List<RawReferenceData> References { get; }
     internal List<RawAnalyzerData> Analyzers { get; }
-    internal List<(string FilePath, string ContentHash, RawContentKind Kind)> Contents { get; }
+    internal List<RawContent> Contents { get; }
     internal List<RawResourceData> Resources { get; }
 
     /// <summary>
@@ -86,7 +105,7 @@ internal sealed class RawCompilationData
         CommandLineArguments arguments,
         List<RawReferenceData> references,
         List<RawAnalyzerData> analyzers,
-        List<(string FilePath, string ContentHash, RawContentKind Kind)> contents,
+        List<RawContent> contents,
         List<RawResourceData> resources,
         bool readGeneratedFiles)
     {

--- a/src/Basic.CompilerLog.Util/RawCompilationData.cs
+++ b/src/Basic.CompilerLog.Util/RawCompilationData.cs
@@ -16,6 +16,7 @@ internal enum RawContentKind
     AdditionalText,
     AnalyzerConfig,
     Embed,
+    EmbedLine,
     SourceLink,
     RuleSet,
     AppConfig,

--- a/src/Basic.CompilerLog.Util/RawCompilationData.cs
+++ b/src/Basic.CompilerLog.Util/RawCompilationData.cs
@@ -16,6 +16,12 @@ internal enum RawContentKind
     AdditionalText,
     AnalyzerConfig,
     Embed,
+
+    /// <summary>
+    /// This represents a #line directive target in a file that was embedded. These are different
+    /// than normal line directives in that they are embedded into the compilation as well so the
+    /// file is read from disk.
+    /// </summary>
     EmbedLine,
     SourceLink,
     RuleSet,

--- a/src/Basic.CompilerLog.Util/RoslynUtil.cs
+++ b/src/Basic.CompilerLog.Util/RoslynUtil.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Basic.CompilerLog.Util;
+
+internal static class RoslynUtil
+{
+    internal static SourceText GetSourceText(string filePath, SourceHashAlgorithm checksumAlgorithm, bool canBeEmbedded)
+    {
+        var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        return GetSourceText(stream, checksumAlgorithm, canBeEmbedded);
+    }
+
+    /// <summary>
+    /// Get a source text 
+    /// </summary>
+    /// <remarks>
+    /// TODO: need to expose the real API for how the compiler reads source files. 
+    /// move this comment to the rehydration code when we write it.
+    /// </remarks>
+    internal static SourceText GetSourceText(Stream stream, SourceHashAlgorithm checksumAlgorithm, bool canBeEmbedded) =>
+        SourceText.From(stream, checksumAlgorithm: checksumAlgorithm, canBeEmbedded: canBeEmbedded);
+
+    internal static SyntaxTree[] ParseAll(IReadOnlyList<(SourceText SourceText, string Path)> sourceTextList, ParseOptions parseOptions) =>
+        parseOptions switch
+        {
+            CSharpParseOptions csharp => ParseAllCSharp(sourceTextList, csharp),
+            VisualBasicParseOptions vb => ParseAllVisualBasic(sourceTextList, vb),
+            _ => throw new ArgumentException(nameof(parseOptions)),
+        };
+
+    internal static VisualBasicSyntaxTree[] ParseAllVisualBasic(IReadOnlyList<(SourceText SourceText, string Path)> sourceTextList, VisualBasicParseOptions parseOptions)
+    {
+        if (sourceTextList.Count == 0)
+        {
+            return Array.Empty<VisualBasicSyntaxTree>();
+        }
+
+        var syntaxTrees = new VisualBasicSyntaxTree[sourceTextList.Count];
+        Parallel.For(
+            0,
+            sourceTextList.Count,
+            i =>
+            {
+                var t = sourceTextList[i];
+                syntaxTrees[i] = (VisualBasicSyntaxTree)VisualBasicSyntaxTree.ParseText(t.SourceText, parseOptions, t.Path);
+            });
+        return syntaxTrees;
+    }
+
+    internal static CSharpSyntaxTree[] ParseAllCSharp(IReadOnlyList<(SourceText SourceText, string Path)> sourceTextList, CSharpParseOptions parseOptions)
+    {
+        if (sourceTextList.Count == 0)
+        {
+            return Array.Empty<CSharpSyntaxTree>();
+        }
+
+        var syntaxTrees = new CSharpSyntaxTree[sourceTextList.Count];
+        Parallel.For(
+            0,
+            sourceTextList.Count,
+            i =>
+            {
+                var t = sourceTextList[i];
+                syntaxTrees[i] = (CSharpSyntaxTree)CSharpSyntaxTree.ParseText(t.SourceText, parseOptions, t.Path);
+            });
+        return syntaxTrees;
+    }
+}

--- a/src/Basic.CompilerLog.Util/SolutionReader.cs
+++ b/src/Basic.CompilerLog.Util/SolutionReader.cs
@@ -97,6 +97,7 @@ public sealed class SolutionReader : IDisposable
                 case RawContentKind.Win32Icon:
                 case RawContentKind.CryptoKeyFile:
                 case RawContentKind.Embed:
+                case RawContentKind.EmbedLine:
                     // Not exposed via the workspace APIs yet
                     break;
                 default:

--- a/src/Scratch/Program.cs
+++ b/src/Scratch/Program.cs
@@ -12,12 +12,12 @@ using TraceReloggerLib;
 
 #pragma warning disable 8321
 
-// var filePath = @"c:\users\jaredpar\temp\console\msbuild.binlog";
+var filePath = @"c:\users\jaredpar\temp\console\msbuild.binlog";
 // var filePath = @"C:\Users\jaredpar\code\MudBlazor\src\msbuild.binlog";
 // var filePath = @"C:\Users\jaredpar\code\roslyn\src\Compilers\Core\Portable\msbuild.binlog";
 // var filePath = @"C:\Users\jaredpar\Downloads\Roslyn.complog";
 // var filePath = @"C:\Users\jaredpar\code\wt\ros2\artifacts\log\Debug\Build.binlog";
-var filePath = @"C:\Users\jaredpar\code\roslyn\artifacts\log\Debug\Build.binlog";
+// var filePath = @"C:\Users\jaredpar\code\roslyn\artifacts\log\Debug\Build.binlog";
 //var filePath = @"C:\Users\jaredpar\code\roslyn\src\Compilers\CSharp\csc\msbuild.binlog";
 
 //TestDiagnostics(filePath);
@@ -26,7 +26,7 @@ var filePath = @"C:\Users\jaredpar\code\roslyn\artifacts\log\Debug\Build.binlog"
 
 // await SolutionScratchAsync(filePath);
 
-using var reader = CompilerLogReader.Create(@"C:\Users\jaredpar\Downloads\7.0.306.zip.binlog");
+using var reader = CompilerLogReader.Create(filePath);
 
 VerifyAll(filePath);
 Console.WriteLine("Done");

--- a/src/Shared/DotnetUtil.cs
+++ b/src/Shared/DotnetUtil.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
+using System.Configuration.Internal;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -28,6 +29,22 @@ internal static class DotnetUtil
     internal static ProcessResult New(string args, string? workingDirectory = null) => Command($"new {args}", workingDirectory);
 
     internal static ProcessResult Build(string args, string? workingDirectory = null) => Command($"build {args}", workingDirectory);
+
+    internal static void AddProjectProperty(string property, string workingDirectory)
+    {
+        var projectFile = Directory.EnumerateFiles(workingDirectory, "*proj").Single();
+        var lines = File.ReadAllLines(projectFile);
+        using var writer = new StreamWriter(projectFile, append: false);
+        foreach (var line in lines)
+        {
+            if (line.Contains("</PropertyGroup>"))
+            {
+                writer.WriteLine(property);
+            }
+
+            writer.WriteLine(line);
+        }
+    }
 
     internal static List<string> GetSdkDirectories()
     {


### PR DESCRIPTION
This rounds out a few of the corner cases in `#line` directive support. 

The one issue that remains is when the user combines `/embed` and `#line` directives with full paths the resulting compilation is not 100% portable between machines. There is simply no way to redirect where the compiler attempts to read the target off of disk hence we're stuck with the original path. Filed [a bug](https://github.com/dotnet/roslyn/issues/69659) with roslyn to track fixing this.