### PR TITLE
Support project files for command targets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/src/Basic.CompilerLog/bin/Debug/net7.0/Basic.CompilerLog.dll",
-            "args": [],
+            "args": ["rsp", "c:\\users\\jaredpar\\temp\\console\\console.csproj"],
             "cwd": "${workspaceFolder}/src/Basic.CompilerLog",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",

--- a/src/Basic.CompilerLog/FilterOptionSet.cs
+++ b/src/Basic.CompilerLog/FilterOptionSet.cs
@@ -11,7 +11,7 @@ internal sealed class FilterOptionSet : OptionSet
 
     internal FilterOptionSet(bool includeNoneHost = false)
     {
-        Add("include", "include all compilation kinds", i => { if (i != null) IncludeAllKinds = true; });
+        Add("include", "include all compilation kinds", i => { if (i is not null) IncludeAllKinds = true; });
         Add("targetframework=", "", TargetFrameworks.Add, hidden: true);
         Add("framework=", "include only compilations for the target framework (allows multiple)", TargetFrameworks.Add);
         Add("n|projectName=", "include only compilations with the project name", (string n) => ProjectName = n);

--- a/src/Basic.CompilerLog/Program.cs
+++ b/src/Basic.CompilerLog/Program.cs
@@ -570,9 +570,11 @@ string GetLogFilePath(List<string> extra)
     string? logFilePath;
     IEnumerable<string> args = Array.Empty<string>();
     string baseDirectory = CurrentDirectory;
+    var printFile = false;
     if (extra.Count == 0)
     {
         logFilePath = FindLogFilePath(baseDirectory);
+        printFile = true;
     }
     else
     {
@@ -582,12 +584,19 @@ string GetLogFilePath(List<string> extra)
         {
             baseDirectory = logFilePath;
             logFilePath = FindLogFilePath(baseDirectory);
+            printFile = true;
         }
     }
 
     if (logFilePath is null)
     {
         throw CreateOptionException();
+    }
+
+    // If the file wasn't explicitly specified let the user know what file we are using
+    if (printFile)
+    {
+        WriteLine($"Using {logFilePath}");
     }
 
     switch (Path.GetExtension(logFilePath))


### PR DESCRIPTION
Build files can now be the targets of commands. So you can now say `complog create console.csproj`. Under the hood the tool will run `dotnet build`, grab the binary log and process that for the command. Should simplify a lot of scenarios.