### PR TITLE
Avoid running CI for doc only changes

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,8 +6,14 @@ name: Build and Test
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+    - 'doc/**'
+    - 'README.md'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+    - 'doc/**'
+    - 'README.md'
 
 jobs:
   build:


### PR DESCRIPTION
Observed it's run unnecessarily in https://github.com/jaredpar/basic-compilerlog/pull/63